### PR TITLE
Add OneLogin support

### DIFF
--- a/samlsp/samlsp.go
+++ b/samlsp/samlsp.go
@@ -42,9 +42,17 @@ func New(opts Options) (*Middleware, error) {
 	if opts.IDPMetadataURL == "" {
 		return m, nil
 	}
+	c := http.DefaultClient
+	req, err := http.NewRequest("GET", opts.IDPMetadataURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	// Some providers (like OneLogin) do not work properly unless the User-Agent header is specified.
+	// Setting the user agent prevents the 403 Forbidden errors.
+	req.Header.Set("User-Agent", "Golang")
 
 	for i := 0; true; i++ {
-		resp, err := http.Get(opts.IDPMetadataURL)
+		resp, err := c.Do(req)
 		if err == nil && resp.StatusCode != http.StatusOK {
 			err = fmt.Errorf("%d %s", resp.StatusCode, resp.Status)
 		}

--- a/service_provider.go
+++ b/service_provider.go
@@ -350,8 +350,8 @@ func (sp *ServiceProvider) ParseResponse(req *http.Request, possibleRequestIDs [
 		if err := xmlsec.Verify(sp.getIDPSigningCert(), rawResponseBuf,
 			xmlsec.SignatureOptions{
 				XMLID: []xmlsec.XMLIDOption{{
-					ElementName:      "Response",
-					ElementNamespace: "urn:oasis:names:tc:SAML:2.0:protocol",
+					ElementName:      "Assertion",
+					ElementNamespace: "urn:oasis:names:tc:SAML:2.0:assertion",
 					AttributeName:    "ID",
 				}},
 			}); err != nil {


### PR DESCRIPTION
This PR is still work in progress - it is definitely not ready to be merged.

I raised the PR as it's easier to discuss my code changes. This code works with OneLogin and it also works with testshib.org.

I am not a SAML expert and would like to discuss the changes with you since they break the existing unit tests. A colleague of mine told me that we should be verifying the signature of the Assertion element and not the Response element - when I changed that it suddenly worked...