### PR TITLE
OneLogin SAML integration

### DIFF
--- a/samlsp/samlsp.go
+++ b/samlsp/samlsp.go
@@ -43,8 +43,17 @@ func New(opts Options) (*Middleware, error) {
 		return m, nil
 	}
 
+	c := http.DefaultClient
+	req, err := http.NewRequest("GET", opts.IDPMetadataURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	// Some providers (like OneLogin) do not work properly unless the User-Agent header is specified.
+	// Setting the user agent prevents the 403 Forbidden errors.
+	req.Header.Set("User-Agent", "Golang; github.com/crewjam/saml")
+
 	for i := 0; true; i++ {
-		resp, err := http.Get(opts.IDPMetadataURL)
+		resp, err := c.Do(req)
 		if err == nil && resp.StatusCode != http.StatusOK {
 			err = fmt.Errorf("%d %s", resp.StatusCode, resp.Status)
 		}


### PR DESCRIPTION
This PR allows the package to be used with OneLogin. The major problem right now is that the package cannot get the metadata XML automatically, unless we specify an user-agent string for the request.