### PR TITLE
ServiceProvider: split ParseResponse() up into ValidateResponse()

### DIFF
--- a/service_provider.go
+++ b/service_provider.go
@@ -308,6 +308,14 @@ func (sp *ServiceProvider) ParseResponse(req *http.Request, possibleRequestIDs [
 		retErr.PrivateErr = fmt.Errorf("cannot parse base64: %s", err)
 		return nil, retErr
 	}
+
+	return sp.ValidateResponse(rawResponseBuf, possibleRequestIDs, now)
+}
+
+func (sp *ServiceProvider) ValidateResponse(rawResponseBuf []byte, possibleRequestIDs []string, now time.Time) (*Assertion, error) {
+	retErr := &InvalidResponseError{
+		Now: now,
+	}
 	retErr.Response = string(rawResponseBuf)
 
 	// do some validation first before we decrypt


### PR DESCRIPTION
Caller may already have the bytes of the response and not the http.Request.
Allow that caller to call ValidateResponse().