### PR TITLE
Update middleware.go

### DIFF
--- a/samlsp/middleware.go
+++ b/samlsp/middleware.go
@@ -240,7 +240,7 @@ func (m *Middleware) Authorize(w http.ResponseWriter, r *http.Request, assertion
 
 		// delete the cookie
 		stateCookie.Value = ""
-		stateCookie.Expires = time.Date(2016, 1, 1, 0, 0, 0, 0, time.UTC) // any time in the past, but not the zero time
+		stateCookie.Expires = time.Time{}.Add(time.Second) // past time as close to epoch as possible, but not zero time.Time{}
 		http.SetCookie(w, stateCookie)
 	}
 

--- a/samlsp/middleware.go
+++ b/samlsp/middleware.go
@@ -240,7 +240,7 @@ func (m *Middleware) Authorize(w http.ResponseWriter, r *http.Request, assertion
 
 		// delete the cookie
 		stateCookie.Value = ""
-		stateCookie.Expires = time.Time{}
+		stateCookie.Expires = time.Date(2016, 1, 1, 0, 0, 0, 0, time.UTC) // any time in the past, but not the zero time
 		http.SetCookie(w, stateCookie)
 	}
 


### PR DESCRIPTION
Delete cookie with time.Time{} just creates a new (empty) cookie with no expiry. You need to use a non-zero time.Time object to distinguish from an omitted expiry time.