### PR TITLE
Use time.Unix(1,0) not time.Time{}.Add(time.Second)

### DIFF
--- a/samlsp/middleware.go
+++ b/samlsp/middleware.go
@@ -240,7 +240,7 @@ func (m *Middleware) Authorize(w http.ResponseWriter, r *http.Request, assertion
 
 		// delete the cookie
 		stateCookie.Value = ""
-		stateCookie.Expires = time.Time{}.Add(time.Second) // past time as close to epoch as possible, but not zero time.Time{}
+		stateCookie.Expires = time.Unix(0,1) // past time as close to epoch as possible, but not zero time.Time{}
 		http.SetCookie(w, stateCookie)
 	}
 


### PR DESCRIPTION
Cookie year must be at least 1601 and Go's http.Cookie checks for this.