### PR TITLE
BREAKING (IDP): generalize the IDP ServiceProviders

### DIFF
--- a/samlidp/samlidp_test.go
+++ b/samlidp/samlidp_test.go
@@ -139,7 +139,7 @@ OwJlNCASPZRH/JmF8tX0hoHuAQ==
 	c.Assert(err, IsNil)
 
 	test.SP.IDPMetadata = test.Server.IDP.Metadata()
-	test.Server.IDP.ServiceProviders["https://sp.example.com/saml2/metadata"] = test.SP.Metadata()
+	test.Server.serviceProviders["https://sp.example.com/saml2/metadata"] = test.SP.Metadata()
 }
 
 func (test *ServerTest) TestHTTPCanHandleMetadataRequest(c *C) {

--- a/samlidp/service_test.go
+++ b/samlidp/service_test.go
@@ -34,7 +34,7 @@ func (test *ServerTest) TestServicesCrud(c *C) {
 	c.Assert(w.Code, Equals, http.StatusOK)
 	c.Assert(string(w.Body.Bytes()), Equals, "{\"services\":[\"sp\"]}\n")
 
-	c.Assert(test.Server.IDP.ServiceProviders, HasLen, 2)
+	c.Assert(test.Server.serviceProviders, HasLen, 2)
 
 	w = httptest.NewRecorder()
 	r, _ = http.NewRequest("DELETE", "https://idp.example.com/services/sp", nil)
@@ -46,5 +46,5 @@ func (test *ServerTest) TestServicesCrud(c *C) {
 	test.Server.ServeHTTP(w, r)
 	c.Assert(w.Code, Equals, http.StatusOK)
 	c.Assert(string(w.Body.Bytes()), Equals, "{\"services\":[]}\n")
-	c.Assert(test.Server.IDP.ServiceProviders, HasLen, 1)
+	c.Assert(test.Server.serviceProviders, HasLen, 1)
 }


### PR DESCRIPTION
Before the list of service providers for the IDP was in a map. This
commit replaces the map with an interface that performs the lookup
at runtime.