### PR TITLE
Use interface for logging to allow structured logs

### DIFF
--- a/example/service.go
+++ b/example/service.go
@@ -9,7 +9,6 @@ import (
 	"encoding/xml"
 	"flag"
 	"fmt"
-	"log"
 	"net/http"
 	"net/url"
 	"strings"
@@ -19,6 +18,7 @@ import (
 	"github.com/zenazn/goji"
 	"github.com/zenazn/goji/web"
 
+	"github.com/crewjam/saml/logger"
 	"github.com/crewjam/saml/samlsp"
 )
 
@@ -100,6 +100,7 @@ OwJlNCASPZRH/JmF8tX0hoHuAQ==
 )
 
 func main() {
+	logr := logger.DefaultLogger
 	rootURLstr := flag.String("url", "https://962766ce.ngrok.io", "The base URL of this service")
 	idpMetadataURLstr := flag.String("idp", "https://516becc2.ngrok.io/metadata", "The metadata URL for the IDP")
 	flag.Parse()
@@ -126,12 +127,13 @@ func main() {
 	samlSP, err := samlsp.New(samlsp.Options{
 		URL:               *rootURL,
 		Key:               keyPair.PrivateKey.(*rsa.PrivateKey),
+		Logger:            logr,
 		Certificate:       keyPair.Leaf,
 		AllowIDPInitiated: true,
 		IDPMetadataURL:    idpMetadataURL,
 	})
 	if err != nil {
-		log.Fatalf("%s", err)
+		logr.Fatalf("%s", err)
 	}
 
 	// register with the service provider

--- a/identity_provider_test.go
+++ b/identity_provider_test.go
@@ -18,6 +18,7 @@ import (
 	"os"
 
 	"github.com/beevik/etree"
+	"github.com/crewjam/saml/logger"
 	"github.com/crewjam/saml/testsaml"
 	"github.com/crewjam/saml/xmlenc"
 	"github.com/dgrijalva/jwt-go"
@@ -125,6 +126,7 @@ OwJlNCASPZRH/JmF8tX0hoHuAQ==
 	test.IDP = IdentityProvider{
 		Key:         test.Key,
 		Certificate: test.Certificate,
+		Logger:      logger.DefaultLogger,
 		MetadataURL: mustParseURL("https://idp.example.com/saml/metadata"),
 		SSOURL:      mustParseURL("https://idp.example.com/saml/sso"),
 		ServiceProviderProvider: &mockServiceProviderProvider{

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -1,0 +1,31 @@
+package logger
+
+import (
+	"log"
+	"os"
+)
+
+// Interface provides the minimal logging interface
+type Interface interface {
+	// Printf prints to the logger using the format.
+	Printf(format string, v ...interface{})
+	// Print prints to the logger.
+	Print(v ...interface{})
+	// Println prints new line.
+	Println(v ...interface{})
+	// Fatal is equivalent to Print() followed by a call to os.Exit(1).
+	Fatal(v ...interface{})
+	// Fatalf is equivalent to Printf() followed by a call to os.Exit(1).
+	Fatalf(format string, v ...interface{})
+	// Fatalln is equivalent to Println() followed by a call to os.Exit(1).
+	Fatalln(v ...interface{})
+	// Panic is equivalent to Print() followed by a call to panic().
+	Panic(v ...interface{})
+	// Panicf is equivalent to Printf() followed by a call to panic().
+	Panicf(format string, v ...interface{})
+	// Panicln is equivalent to Println() followed by a call to panic().
+	Panicln(v ...interface{})
+}
+
+// DefaultLogger logs messages to os.Stdout
+var DefaultLogger = log.New(os.Stdout, "", log.LstdFlags)

--- a/samlidp/samlidp_test.go
+++ b/samlidp/samlidp_test.go
@@ -16,6 +16,7 @@ import (
 	"crypto/rsa"
 
 	"github.com/crewjam/saml"
+	"github.com/crewjam/saml/logger"
 	"github.com/dgrijalva/jwt-go"
 )
 
@@ -123,6 +124,7 @@ OwJlNCASPZRH/JmF8tX0hoHuAQ==
 		MetadataURL: mustParseURL("https://sp.example.com/saml2/metadata"),
 		AcsURL:      mustParseURL("https://sp.example.com/saml2/acs"),
 		IDPMetadata: &saml.Metadata{},
+		Logger:      logger.DefaultLogger,
 	}
 	test.Key = mustParsePrivateKey("-----BEGIN RSA PRIVATE KEY-----\nMIICXgIBAAKBgQDU8wdiaFmPfTyRYuFlVPi866WrH/2JubkHzp89bBQopDaLXYxi\n3PTu3O6Q/KaKxMOFBqrInwqpv/omOGZ4ycQ51O9I+Yc7ybVlW94lTo2gpGf+Y/8E\nPsVbnZaFutRctJ4dVIp9aQ2TpLiGT0xX1OzBO/JEgq9GzDRf+B+eqSuglwIDAQAB\nAoGBAMuy1eN6cgFiCOgBsB3gVDdTKpww87Qk5ivjqEt28SmXO13A1KNVPS6oQ8SJ\nCT5Azc6X/BIAoJCURVL+LHdqebogKljhH/3yIel1kH19vr4E2kTM/tYH+qj8afUS\nJEmArUzsmmK8ccuNqBcllqdwCZjxL4CHDUmyRudFcHVX9oyhAkEA/OV1OkjM3CLU\nN3sqELdMmHq5QZCUihBmk3/N5OvGdqAFGBlEeewlepEVxkh7JnaNXAXrKHRVu/f/\nfbCQxH+qrwJBANeQERF97b9Sibp9xgolb749UWNlAdqmEpmlvmS202TdcaaT1msU\n4rRLiQN3X9O9mq4LZMSVethrQAdX1whawpkCQQDk1yGf7xZpMJ8F4U5sN+F4rLyM\nRq8Sy8p2OBTwzCUXXK+fYeXjybsUUMr6VMYTRP2fQr/LKJIX+E5ZxvcIyFmDAkEA\nyfjNVUNVaIbQTzEbRlRvT6MqR+PTCefC072NF9aJWR93JimspGZMR7viY6IM4lrr\nvBkm0F5yXKaYtoiiDMzlOQJADqmEwXl0D72ZG/2KDg8b4QZEmC9i5gidpQwJXUc6\nhU+IVQoLxRq0fBib/36K9tcrrO5Ba4iEvDcNY+D8yGbUtA==\n-----END RSA PRIVATE KEY-----\n")
 	test.Certificate = mustParseCertificate("-----BEGIN CERTIFICATE-----\nMIIB7zCCAVgCCQDFzbKIp7b3MTANBgkqhkiG9w0BAQUFADA8MQswCQYDVQQGEwJV\nUzELMAkGA1UECAwCR0ExDDAKBgNVBAoMA2ZvbzESMBAGA1UEAwwJbG9jYWxob3N0\nMB4XDTEzMTAwMjAwMDg1MVoXDTE0MTAwMjAwMDg1MVowPDELMAkGA1UEBhMCVVMx\nCzAJBgNVBAgMAkdBMQwwCgYDVQQKDANmb28xEjAQBgNVBAMMCWxvY2FsaG9zdDCB\nnzANBgkqhkiG9w0BAQEFAAOBjQAwgYkCgYEA1PMHYmhZj308kWLhZVT4vOulqx/9\nibm5B86fPWwUKKQ2i12MYtz07tzukPymisTDhQaqyJ8Kqb/6JjhmeMnEOdTvSPmH\nO8m1ZVveJU6NoKRn/mP/BD7FW52WhbrUXLSeHVSKfWkNk6S4hk9MV9TswTvyRIKv\nRsw0X/gfnqkroJcCAwEAATANBgkqhkiG9w0BAQUFAAOBgQCMMlIO+GNcGekevKgk\nakpMdAqJfs24maGb90DvTLbRZRD7Xvn1MnVBBS9hzlXiFLYOInXACMW5gcoRFfeT\nQLSouMM8o57h0uKjfTmuoWHLQLi6hnF+cvCsEFiJZ4AbF+DgmO6TarJ8O05t8zvn\nOwJlNCASPZRH/JmF8tX0hoHuAQ==\n-----END CERTIFICATE-----\n")
@@ -131,10 +133,11 @@ OwJlNCASPZRH/JmF8tX0hoHuAQ==
 
 	var err error
 	test.Server, err = New(Options{
-		URL:         url.URL{Scheme: "https", Host: "idp.example.com"},
-		Key:         test.Key,
 		Certificate: test.Certificate,
+		Key:         test.Key,
+		Logger:      logger.DefaultLogger,
 		Store:       &test.Store,
+		URL:         url.URL{Scheme: "https", Host: "idp.example.com"},
 	})
 	c.Assert(err, IsNil)
 

--- a/samlidp/service.go
+++ b/samlidp/service.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"encoding/xml"
 	"fmt"
-	"log"
 	"net/http"
 	"os"
 
@@ -40,7 +39,7 @@ func (s *Server) GetServiceProvider(r *http.Request, serviceProviderID string) (
 func (s *Server) HandleListServices(c web.C, w http.ResponseWriter, r *http.Request) {
 	services, err := s.Store.List("/services/")
 	if err != nil {
-		log.Printf("ERROR: %s", err)
+		s.logger.Printf("ERROR: %s", err)
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return
 	}
@@ -56,7 +55,7 @@ func (s *Server) HandleGetService(c web.C, w http.ResponseWriter, r *http.Reques
 	service := Service{}
 	err := s.Store.Get(fmt.Sprintf("/services/%s", c.URLParams["id"]), &service)
 	if err != nil {
-		log.Printf("ERROR: %s", err)
+		s.logger.Printf("ERROR: %s", err)
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return
 	}
@@ -68,14 +67,14 @@ func (s *Server) HandleGetService(c web.C, w http.ResponseWriter, r *http.Reques
 func (s *Server) HandlePutService(c web.C, w http.ResponseWriter, r *http.Request) {
 	service := Service{}
 	if err := xml.NewDecoder(r.Body).Decode(&service.Metadata); err != nil {
-		log.Printf("ERROR: %s", err)
+		s.logger.Printf("ERROR: %s", err)
 		http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
 		return
 	}
 
 	err := s.Store.Put(fmt.Sprintf("/services/%s", c.URLParams["id"]), &service)
 	if err != nil {
-		log.Printf("ERROR: %s", err)
+		s.logger.Printf("ERROR: %s", err)
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return
 	}
@@ -92,13 +91,13 @@ func (s *Server) HandleDeleteService(c web.C, w http.ResponseWriter, r *http.Req
 	service := Service{}
 	err := s.Store.Get(fmt.Sprintf("/services/%s", c.URLParams["id"]), &service)
 	if err != nil {
-		log.Printf("ERROR: %s", err)
+		s.logger.Printf("ERROR: %s", err)
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return
 	}
 
 	if err := s.Store.Delete(fmt.Sprintf("/services/%s", c.URLParams["id"])); err != nil {
-		log.Printf("ERROR: %s", err)
+		s.logger.Printf("ERROR: %s", err)
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return
 	}

--- a/samlidp/shortcut.go
+++ b/samlidp/shortcut.go
@@ -3,7 +3,6 @@ package samlidp
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"net/http"
 
 	"github.com/zenazn/goji/web"
@@ -91,7 +90,7 @@ func (s *Server) HandleIDPInitiated(c web.C, w http.ResponseWriter, r *http.Requ
 	shortcutName := c.URLParams["shortcut"]
 	shortcut := Shortcut{}
 	if err := s.Store.Get(fmt.Sprintf("/shortcuts/%s", shortcutName), &shortcut); err != nil {
-		log.Printf("ERROR: %s", err)
+		s.logger.Printf("ERROR: %s", err)
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return
 	}

--- a/samlidp/user.go
+++ b/samlidp/user.go
@@ -3,7 +3,6 @@ package samlidp
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"net/http"
 
 	"github.com/zenazn/goji/web"
@@ -28,7 +27,7 @@ type User struct {
 func (s *Server) HandleListUsers(c web.C, w http.ResponseWriter, r *http.Request) {
 	users, err := s.Store.List("/users/")
 	if err != nil {
-		log.Printf("ERROR: %s", err)
+		s.logger.Printf("ERROR: %s", err)
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return
 	}
@@ -44,7 +43,7 @@ func (s *Server) HandleGetUser(c web.C, w http.ResponseWriter, r *http.Request) 
 	user := User{}
 	err := s.Store.Get(fmt.Sprintf("/users/%s", c.URLParams["id"]), &user)
 	if err != nil {
-		log.Printf("ERROR: %s", err)
+		s.logger.Printf("ERROR: %s", err)
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return
 	}
@@ -59,7 +58,7 @@ func (s *Server) HandleGetUser(c web.C, w http.ResponseWriter, r *http.Request) 
 func (s *Server) HandlePutUser(c web.C, w http.ResponseWriter, r *http.Request) {
 	user := User{}
 	if err := json.NewDecoder(r.Body).Decode(&user); err != nil {
-		log.Printf("ERROR: %s", err)
+		s.logger.Printf("ERROR: %s", err)
 		http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
 		return
 	}
@@ -69,7 +68,7 @@ func (s *Server) HandlePutUser(c web.C, w http.ResponseWriter, r *http.Request) 
 		var err error
 		user.HashedPassword, err = bcrypt.GenerateFromPassword([]byte(*user.PlaintextPassword), bcrypt.DefaultCost)
 		if err != nil {
-			log.Printf("ERROR: %s", err)
+			s.logger.Printf("ERROR: %s", err)
 			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 			return
 		}
@@ -82,7 +81,7 @@ func (s *Server) HandlePutUser(c web.C, w http.ResponseWriter, r *http.Request) 
 		case err == ErrNotFound:
 			// nop
 		default:
-			log.Printf("ERROR: %s", err)
+			s.logger.Printf("ERROR: %s", err)
 			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 			return
 		}
@@ -91,7 +90,7 @@ func (s *Server) HandlePutUser(c web.C, w http.ResponseWriter, r *http.Request) 
 
 	err := s.Store.Put(fmt.Sprintf("/users/%s", c.URLParams["id"]), &user)
 	if err != nil {
-		log.Printf("ERROR: %s", err)
+		s.logger.Printf("ERROR: %s", err)
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return
 	}
@@ -102,7 +101,7 @@ func (s *Server) HandlePutUser(c web.C, w http.ResponseWriter, r *http.Request) 
 func (s *Server) HandleDeleteUser(c web.C, w http.ResponseWriter, r *http.Request) {
 	err := s.Store.Delete(fmt.Sprintf("/users/%s", c.URLParams["id"]))
 	if err != nil {
-		log.Printf("ERROR: %s", err)
+		s.logger.Printf("ERROR: %s", err)
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return
 	}

--- a/samlsp/middleware_test.go
+++ b/samlsp/middleware_test.go
@@ -20,6 +20,7 @@ import (
 	"crypto/x509"
 
 	"github.com/crewjam/saml"
+	"github.com/crewjam/saml/logger"
 	"github.com/crewjam/saml/testsaml"
 )
 
@@ -73,6 +74,7 @@ func (test *MiddlewareTest) SetUpTest(c *C) {
 			MetadataURL: mustParseURL("https://15661444.ngrok.io/saml2/metadata"),
 			AcsURL:      mustParseURL("https://15661444.ngrok.io/saml2/acs"),
 			IDPMetadata: &saml.Metadata{},
+			Logger:      logger.DefaultLogger,
 		},
 		CookieName:   "ttt",
 		CookieMaxAge: time.Hour * 2,

--- a/service_provider.go
+++ b/service_provider.go
@@ -16,13 +16,16 @@ import (
 	"time"
 
 	"github.com/beevik/etree"
+	"github.com/crewjam/saml/logger"
 	"github.com/crewjam/saml/xmlenc"
 	dsig "github.com/russellhaering/goxmldsig"
 	"github.com/russellhaering/goxmldsig/etreeutils"
 )
 
+// NameIDFormat is the format of the id
 type NameIDFormat string
 
+// Name ID formats
 const (
 	UnspecifiedNameIDFormat  NameIDFormat = "urn:oasis:names:tc:SAML:2.0:nameid-format:unspecified"
 	TransientNameIDFormat    NameIDFormat = "urn:oasis:names:tc:SAML:2.0:nameid-format:transient"
@@ -63,6 +66,9 @@ type ServiceProvider struct {
 	// MetadataValidDuration is a duration used to calculate validUntil
 	// attribute in the metadata endpoint
 	MetadataValidDuration time.Duration
+
+	// Logger is used to log messages for example in the event of errors
+	Logger logger.Interface
 }
 
 // MaxIssueDelay is the longest allowed time between when a SAML assertion is


### PR DESCRIPTION
This PR replaces the logger from the standard library (e.g. `log.Println()`) with a logging interface. The code doesn't change the functionality of the library.
Using the default logger is a big problem my team. We have deployed our application in Kubernetes and we use the ELK stack to browse/query our logs. Unfortunately, this library logs multi-line messages with `log.Println`, which causes the logs to be split into multiple messages in Kibana. In addition to that we have each app deployed into multiple environments and sometimes we want to query logs by environment or docker container etc.
Using this interface will still allow you to use standard library logger, but will also allow other users to replace it with Logrus, for example, and output logs in structured JSON format. 