### PR TITLE
Tls config

### DIFF
--- a/samlsp/samlsp.go
+++ b/samlsp/samlsp.go
@@ -63,10 +63,9 @@ func New(opts Options) (*Middleware, error) {
 	c := http.DefaultClient
 	if opts.TLS != nil {
 		//Support for custom TLS certificate trusts
-		tr := http.Transport{
+		c.Transport = &http.Transport{
 			TLSClientConfig: opts.TLS,
 		}
-		c.Transport = &tr
 	}
 	req, err := http.NewRequest("GET", opts.IDPMetadataURL.String(), nil)
 	if err != nil {

--- a/samlsp/samlsp.go
+++ b/samlsp/samlsp.go
@@ -4,6 +4,7 @@ package samlsp
 
 import (
 	"crypto/rsa"
+	"crypto/tls"
 	"crypto/x509"
 	"encoding/xml"
 	"fmt"
@@ -25,6 +26,7 @@ type Options struct {
 	AllowIDPInitiated bool
 	IDPMetadata       *saml.EntityDescriptor
 	IDPMetadataURL    *url.URL
+	TLS               *tls.Config
 }
 
 // New creates a new Middleware
@@ -59,6 +61,13 @@ func New(opts Options) (*Middleware, error) {
 	}
 
 	c := http.DefaultClient
+	if opts.TLS != nil {
+		//Support for custom TLS certificate trusts
+		tr := http.Transport{
+			TLSClientConfig: opts.TLS,
+		}
+		c.Transport = &tr
+	}
 	req, err := http.NewRequest("GET", opts.IDPMetadataURL.String(), nil)
 	if err != nil {
 		return nil, err

--- a/samlsp/samlsp.go
+++ b/samlsp/samlsp.go
@@ -4,7 +4,6 @@ package samlsp
 
 import (
 	"crypto/rsa"
-	"crypto/tls"
 	"crypto/x509"
 	"encoding/xml"
 	"fmt"
@@ -26,7 +25,7 @@ type Options struct {
 	AllowIDPInitiated bool
 	IDPMetadata       *saml.EntityDescriptor
 	IDPMetadataURL    *url.URL
-	TLS               *tls.Config
+	HTTPClient        *http.Client
 }
 
 // New creates a new Middleware
@@ -60,12 +59,9 @@ func New(opts Options) (*Middleware, error) {
 		return m, nil
 	}
 
-	c := http.DefaultClient
-	if opts.TLS != nil {
-		//Support for custom TLS certificate trusts
-		c.Transport = &http.Transport{
-			TLSClientConfig: opts.TLS,
-		}
+	c := opts.HTTPClient
+	if c == nil {
+		c = http.DefaultClient
 	}
 	req, err := http.NewRequest("GET", opts.IDPMetadataURL.String(), nil)
 	if err != nil {


### PR DESCRIPTION
Allow programs to set the TLS configuration for outgoing HTTP connections.  This supports testing environments where full certificate trusts may not exist.