### PR TITLE
Fix time format to match spec

### DIFF
--- a/time.go
+++ b/time.go
@@ -4,7 +4,7 @@ import "time"
 
 type RelaxedTime time.Time
 
-const timeFormat = "2006-01-02T15:04:05.999Z07:00"
+const timeFormat = "2006-01-02T15:04:05.999Z"
 
 func (m RelaxedTime) MarshalText() ([]byte, error) {
 	// According to section 1.2.2 of the OASIS SAML 1.1 spec, we can't trust


### PR DESCRIPTION
The W3C spec for the XML type xs:dateTime does not allow for a timezone (as they are supposed to be in UTC).

This was discovered when trying to use simpleSAMLphp as a SP since it checks this format very strictly.