### PR TITLE
Allow EntitiesDescriptor in IDP

### DIFF
--- a/samlidp/service.go
+++ b/samlidp/service.go
@@ -66,13 +66,17 @@ func (s *Server) HandleGetService(c web.C, w http.ResponseWriter, r *http.Reques
 // service metadata in the request body and stores it.
 func (s *Server) HandlePutService(c web.C, w http.ResponseWriter, r *http.Request) {
 	service := Service{}
-	if err := xml.NewDecoder(r.Body).Decode(&service.Metadata); err != nil {
+
+	metadata, err := getSPMetadata(r.Body)
+	if err != nil {
 		s.logger.Printf("ERROR: %s", err)
 		http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
 		return
 	}
 
-	err := s.Store.Put(fmt.Sprintf("/services/%s", c.URLParams["id"]), &service)
+	service.Metadata = *metadata
+
+	err = s.Store.Put(fmt.Sprintf("/services/%s", c.URLParams["id"]), &service)
 	if err != nil {
 		s.logger.Printf("ERROR: %s", err)
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)

--- a/samlidp/util.go
+++ b/samlidp/util.go
@@ -1,6 +1,15 @@
 package samlidp
 
-import "github.com/crewjam/saml"
+import (
+	"errors"
+	"io/ioutil"
+
+	"encoding/xml"
+
+	"io"
+
+	"github.com/crewjam/saml"
+)
 
 func randomBytes(n int) []byte {
 	rv := make([]byte, n)
@@ -8,4 +17,37 @@ func randomBytes(n int) []byte {
 		panic(err)
 	}
 	return rv
+}
+
+func getSPMetadata(r io.Reader) (spMetadata *saml.EntityDescriptor, err error) {
+	var bytes []byte
+
+	if bytes, err = ioutil.ReadAll(r); err != nil {
+		return nil, err
+	}
+
+	spMetadata = &saml.EntityDescriptor{}
+
+	if err := xml.Unmarshal(bytes, &spMetadata); err != nil {
+		if err.Error() == "expected element type <EntityDescriptor> but have <EntitiesDescriptor>" {
+			entities := &saml.EntitiesDescriptor{}
+
+			if err := xml.Unmarshal(bytes, &entities); err != nil {
+				return nil, err
+			}
+
+			for _, e := range entities.EntityDescriptors {
+				if len(e.SPSSODescriptors) > 0 {
+					return &e, nil
+				}
+			}
+
+			// there were no SPSSODescriptors in the response
+			return nil, errors.New("metadata contained no service provider metadata")
+		}
+
+		return nil, err
+	}
+
+	return spMetadata, nil
 }


### PR DESCRIPTION
This is essentially the same as #31 but for the case where we are the IDP and are attempting to parse SP metadata, such as TestShib's metadata that uses <EntitiesDescriptor> and includes both the SP and IDP metadata in a single file.