### PR TITLE
Allow blank destination in SAML request

### DIFF
--- a/identity_provider.go
+++ b/identity_provider.go
@@ -345,7 +345,7 @@ func (req *IdpAuthnRequest) Validate() error {
 
 	// TODO(ross): is this supposed to be the metdata URL? or the target URL?
 	//   i.e. should idp.SSOURL actually be idp.Metadata().EntityID?
-	if req.Request.Destination != req.IDP.SSOURL.String() {
+	if len(req.Request.Destination) > 0 && req.Request.Destination != req.IDP.SSOURL.String() {
 		return fmt.Errorf("expected destination to be %q, not %q", req.IDP.SSOURL.String(), req.Request.Destination)
 	}
 	if req.Request.IssueInstant.Add(MaxIssueDelay).Before(TimeNow()) {


### PR DESCRIPTION
Some SPs won't include the destination at all, one notable example being G Suite.