### PR TITLE
bugfix: wrong EntityDescriptor selected for some metadata (incl. TestShib)

### DIFF
--- a/samlsp/samlsp.go
+++ b/samlsp/samlsp.go
@@ -101,9 +101,9 @@ func New(opts Options) (*Middleware, error) {
 			}
 
 			err = fmt.Errorf("no entity found with IDPSSODescriptor")
-			for _, e := range entities.EntityDescriptors {
+			for i, e := range entities.EntityDescriptors {
 				if len(e.IDPSSODescriptors) > 0 {
-					entity = &e
+					entity = &entities.EntityDescriptors[i]
 					err = nil
 				}
 			}

--- a/samlsp/samlsp_test.go
+++ b/samlsp/samlsp_test.go
@@ -448,8 +448,11 @@ func (test *ParseTest) TestCanParseTestshibMetadata(c *C) {
 	})
 
 	u := mustParseURL("https://idp.testshib.org/idp/shibboleth")
-	_, err := New(Options{IDPMetadataURL: &u})
+	m, err := New(Options{IDPMetadataURL: &u})
 	c.Assert(err, IsNil)
+	c.Assert(m, NotNil)
+	c.Assert(m.ServiceProvider.IDPMetadata, NotNil)
+	c.Assert(m.ServiceProvider.IDPMetadata.EntityID, Equals, "https://idp.testshib.org/idp/shibboleth")
 }
 
 func (test *ParseTest) TestCanParseGoogleMetadata(c *C) {


### PR DESCRIPTION
`New` would select the wrong `EntityDescriptor` when given a metadata file where:

1. Multiple `<EntityDescriptor>`s were placed underneath an `<EntitiesDescriptor>` tag, _and_
2. At least one of the `<EntityDescriptor>`s was valid (contained a non-empty `<IDPSSODescriptor>` element), but the last `<EntityDescriptor>` in the list was _**not**_.

This PR adds a test for that case, and fixes the bug.