### PR TITLE
Remove 'Failing' from certificate missing check

### DIFF
--- a/xmlenc/decrypt_test.go
+++ b/xmlenc/decrypt_test.go
@@ -63,8 +63,7 @@ func (test *DecryptTest) TestCanDecrypt(c *C) {
 	c.Assert(string(buf), DeepEquals, expectedPlaintext)
 }
 
-// TODO(ross): remove 'Failing' from the function name when PR #80 lands
-func (test *DecryptTest) FailingTestCanDecryptWithoutCertificate(c *C) {
+func (test *DecryptTest) TestCanDecryptWithoutCertificate(c *C) {
 	doc := etree.NewDocument()
 	err := doc.ReadFromString(input)
 	c.Assert(err, IsNil)


### PR DESCRIPTION
Response to https://github.com/crewjam/saml/commit/cb53b639fe422f48b55f8dc5ae0fde53ad71b26d