### PR TITLE
Add support for RSA jwt signature

### DIFF
--- a/samlsp/middleware.go
+++ b/samlsp/middleware.go
@@ -1,14 +1,13 @@
 package samlsp
 
 import (
+	"crypto"
 	"encoding/base64"
 	"encoding/xml"
 	"fmt"
 	"net/http"
 	"strings"
 	"time"
-
-	"crypto"
 
 	"github.com/crewjam/saml"
 	"github.com/dgrijalva/jwt-go"

--- a/samlsp/middleware.go
+++ b/samlsp/middleware.go
@@ -212,6 +212,38 @@ type TokenClaims struct {
 	Attributes map[string][]string `json:"attr"`
 }
 
+func (m *Middleware) getSignedToken(assertion *saml.Assertion) (string, error) {
+	now := saml.TimeNow()
+	claims := TokenClaims{}
+	claims.Audience = m.ServiceProvider.Metadata().EntityID
+	claims.IssuedAt = assertion.IssueInstant.Unix()
+	claims.ExpiresAt = now.Add(m.CookieMaxAge).Unix()
+	claims.NotBefore = now.Unix()
+	if sub := assertion.Subject; sub != nil {
+		if nameID := sub.NameID; nameID != nil {
+			claims.StandardClaims.Subject = nameID.Value
+		}
+	}
+	for _, attributeStatement := range assertion.AttributeStatements {
+		claims.Attributes = map[string][]string{}
+		for _, attr := range attributeStatement.Attributes {
+			claimName := attr.FriendlyName
+			if claimName == "" {
+				claimName = attr.Name
+			}
+			for _, value := range attr.Values {
+				claims.Attributes[claimName] = append(claims.Attributes[claimName], value.Value)
+			}
+		}
+	}
+	signedToken, err := jwt.NewWithClaims(m.JwtSigningMethod,
+		claims).SignedString(m.JwtSigningKey)
+	if err != nil {
+		return "", err
+	}
+	return signedToken, nil
+}
+
 // Authorize is invoked by ServeHTTP when we have a new, valid SAML assertion.
 // It sets a cookie that contains a signed JWT containing the assertion attributes.
 // It then redirects the user's browser to the original URL contained in RelayState.
@@ -245,31 +277,7 @@ func (m *Middleware) Authorize(w http.ResponseWriter, r *http.Request, assertion
 		http.SetCookie(w, stateCookie)
 	}
 
-	now := saml.TimeNow()
-	claims := TokenClaims{}
-	claims.Audience = m.ServiceProvider.Metadata().EntityID
-	claims.IssuedAt = assertion.IssueInstant.Unix()
-	claims.ExpiresAt = now.Add(m.CookieMaxAge).Unix()
-	claims.NotBefore = now.Unix()
-	if sub := assertion.Subject; sub != nil {
-		if nameID := sub.NameID; nameID != nil {
-			claims.StandardClaims.Subject = nameID.Value
-		}
-	}
-	for _, attributeStatement := range assertion.AttributeStatements {
-		claims.Attributes = map[string][]string{}
-		for _, attr := range attributeStatement.Attributes {
-			claimName := attr.FriendlyName
-			if claimName == "" {
-				claimName = attr.Name
-			}
-			for _, value := range attr.Values {
-				claims.Attributes[claimName] = append(claims.Attributes[claimName], value.Value)
-			}
-		}
-	}
-	signedToken, err := jwt.NewWithClaims(m.JwtSigningMethod,
-		claims).SignedString(m.JwtSigningKey)
+	signedToken, err := m.getSignedToken(assertion)
 	if err != nil {
 		panic(err)
 	}

--- a/samlsp/middleware.go
+++ b/samlsp/middleware.go
@@ -58,7 +58,7 @@ type Middleware struct {
 const defaultCookieMaxAge = time.Hour
 const defaultCookieName = "token"
 
-var jwtSigningMethod = jwt.SigningMethodHS256
+var jwtSigningMethod jwt.SigningMethod = jwt.SigningMethodHS256
 
 func randomBytes(n int) []byte {
 	rv := make([]byte, n)
@@ -186,7 +186,7 @@ func (m *Middleware) getPossibleRequestIDs(r *http.Request) []string {
 		m.ServiceProvider.Logger.Printf("getPossibleRequestIDs: cookie: %s", cookie.String())
 
 		jwtParser := jwt.Parser{
-			ValidMethods: []string{jwtSigningMethod.Name},
+			ValidMethods: []string{jwtSigningMethod.Alg()},
 		}
 		token, err := jwtParser.Parse(cookie.Value, func(t *jwt.Token) (interface{}, error) {
 			secretBlock := x509.MarshalPKCS1PrivateKey(m.ServiceProvider.Key)
@@ -229,7 +229,7 @@ func (m *Middleware) Authorize(w http.ResponseWriter, r *http.Request, assertion
 		}
 
 		jwtParser := jwt.Parser{
-			ValidMethods: []string{jwtSigningMethod.Name},
+			ValidMethods: []string{jwtSigningMethod.Alg()},
 		}
 		state, err := jwtParser.Parse(stateCookie.Value, func(t *jwt.Token) (interface{}, error) {
 			return secretBlock, nil

--- a/samlsp/middleware.go
+++ b/samlsp/middleware.go
@@ -271,7 +271,7 @@ func (m *Middleware) Authorize(w http.ResponseWriter, r *http.Request, assertion
 			}
 		}
 	}
-	signedToken, err := jwt.NewWithClaims(jwt.SigningMethodHS256,
+	signedToken, err := jwt.NewWithClaims(jwtSigningMethod,
 		claims).SignedString(secretBlock)
 	if err != nil {
 		panic(err)

--- a/samlsp/middleware_test.go
+++ b/samlsp/middleware_test.go
@@ -79,6 +79,8 @@ func (test *MiddlewareTest) SetUpTest(c *C) {
 		CookieName:       "ttt",
 		CookieMaxAge:     time.Hour * 2,
 		JwtSigningMethod: jwt.SigningMethodHS256,
+		JwtSigningKey:    x509.MarshalPKCS1PrivateKey(test.Key),
+		JwtVerifyKey:     x509.MarshalPKCS1PrivateKey(test.Key),
 	}
 	err := xml.Unmarshal([]byte(test.IDPMetadata), &test.Middleware.ServiceProvider.IDPMetadata)
 	c.Assert(err, IsNil)

--- a/samlsp/middleware_test.go
+++ b/samlsp/middleware_test.go
@@ -76,8 +76,9 @@ func (test *MiddlewareTest) SetUpTest(c *C) {
 			IDPMetadata: &saml.EntityDescriptor{},
 			Logger:      logger.DefaultLogger,
 		},
-		CookieName:   "ttt",
-		CookieMaxAge: time.Hour * 2,
+		CookieName:       "ttt",
+		CookieMaxAge:     time.Hour * 2,
+		JwtSigningMethod: jwt.SigningMethodHS256,
 	}
 	err := xml.Unmarshal([]byte(test.IDPMetadata), &test.Middleware.ServiceProvider.IDPMetadata)
 	c.Assert(err, IsNil)

--- a/samlsp/samlsp.go
+++ b/samlsp/samlsp.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/crewjam/saml"
 	"github.com/crewjam/saml/logger"
+	"github.com/dgrijalva/jwt-go"
 )
 
 // Options represents the parameters for creating a new middleware
@@ -61,6 +62,7 @@ func New(opts Options) (*Middleware, error) {
 		CookieName:        defaultCookieName,
 		CookieMaxAge:      cookieMaxAge,
 		CookieDomain:      opts.URL.Host,
+		JwtSigningMethod:  jwt.SigningMethodHS256,
 	}
 
 	// fetch the IDP metadata if needed.

--- a/samlsp/samlsp.go
+++ b/samlsp/samlsp.go
@@ -63,6 +63,7 @@ func New(opts Options) (*Middleware, error) {
 		CookieMaxAge:      cookieMaxAge,
 		CookieDomain:      opts.URL.Host,
 		JwtSigningMethod:  jwt.SigningMethodHS256,
+		JwtSigningKey:     x509.MarshalPKCS1PrivateKey(opts.Key),
 	}
 
 	// fetch the IDP metadata if needed.

--- a/samlsp/samlsp.go
+++ b/samlsp/samlsp.go
@@ -60,6 +60,9 @@ func New(opts Options) (*Middleware, error) {
 		if _, ok := opts.SigningMethod.(*jwt.SigningMethodHMAC); ok {
 			jwtPrivateKey = x509.MarshalPKCS1PrivateKey(opts.Key)
 			jwtPublicKey = x509.MarshalPKCS1PrivateKey(opts.Key)
+		} else if _, ok := opts.SigningMethod.(*jwt.SigningMethodRSA); ok {
+			jwtPrivateKey = opts.Key
+			jwtPublicKey = opts.Certificate.PublicKey
 		} else {
 			return nil, fmt.Errorf("SAML ServiceProvider Middleware: Unsupported jwt signing method %f", opts.SigningMethod.Alg())
 		}


### PR DESCRIPTION
As discussed in #50 I also have the need for signing tokens using the RSA method.
This allows me to provide tokens to users they can verify without requiring my private key.

By default, the behaviour is unchanged and the signature method is still HS256.
However, it is possible to request signing tokens using RS256 by adding a single argument to Service provider builder.

As RSA works with a pair of private / public keys, it has been required to expose those values to the middleware.