### PR TITLE
Add a break statement

### DIFF
--- a/samlsp/samlsp.go
+++ b/samlsp/samlsp.go
@@ -105,6 +105,7 @@ func New(opts Options) (*Middleware, error) {
 				if len(e.IDPSSODescriptors) > 0 {
 					entity = &e
 					err = nil
+					break
 				}
 			}
 		}


### PR DESCRIPTION
Add a break statement to stop looking at IDPSSODescriptors  once one has been found.