### PR TITLE
Invalid claim names

### DIFF
--- a/samlsp/middleware.go
+++ b/samlsp/middleware.go
@@ -243,7 +243,7 @@ func (m *Middleware) Authorize(w http.ResponseWriter, r *http.Request, assertion
 
 		// delete the cookie
 		stateCookie.Value = ""
-		stateCookie.Expires = time.Unix(1,0) // past time as close to epoch as possible, but not zero time.Time{}
+		stateCookie.Expires = time.Unix(1, 0) // past time as close to epoch as possible, but not zero time.Time{}
 		http.SetCookie(w, stateCookie)
 	}
 
@@ -333,7 +333,8 @@ func (m *Middleware) IsAuthorized(r *http.Request) bool {
 
 	for claimName, claimValues := range tokenClaims.Attributes {
 		for _, claimValue := range claimValues {
-			r.Header.Add("X-Saml-"+claimName, claimValue)
+			cn := strings.Split(claimName, "/")
+			r.Header.Add("X-Saml-"+cn[len(cn)-1], claimValue)
 		}
 	}
 	r.Header.Set("X-Saml-Subject", tokenClaims.Subject)

--- a/samlsp/middleware_test.go
+++ b/samlsp/middleware_test.go
@@ -458,5 +458,5 @@ func (test *MiddlewareTest) TestHandlesInvalidClaimName(c *C) {
 		Header: make(http.Header),
 	}
 	tc.SetHTTPHeader(r)
-	c.Assert(r.Header.Get("group"), Equals, "g1")
+	c.Assert(r.Header.Get("X-Saml-group"), Equals, "g1")
 }

--- a/samlsp/middleware_test.go
+++ b/samlsp/middleware_test.go
@@ -454,7 +454,6 @@ func (test *MiddlewareTest) TestHandlesInvalidClaimName(c *C) {
 	tc := TokenClaims{}
 	tc.Attributes = make(map[string][]string)
 	tc.Attributes["http://claim.com/claims/group"] = []string{"g1"}
-	http.NewRequest(
 	r := &http.Request{
 		Header: make(http.Header),
 	}

--- a/samlsp/middleware_test.go
+++ b/samlsp/middleware_test.go
@@ -449,3 +449,11 @@ func (test *MiddlewareTest) TestHandlesInvalidResponse(c *C) {
 	c.Assert(resp.Header().Get("Location"), Equals, "")
 	c.Assert(resp.Header().Get("Set-Cookie"), Equals, "")
 }
+
+func (test *MiddlewareTest) TestHandlesInvalidClaimName(c *C) {
+	tc := TokenClaims{}
+	tc.Attributes = map[string][]string{"http://claim.com/claims/group": []string{"g1"}}
+	r := &http.Request{}
+	tc.SetHTTPHeader(r)
+	c.Assert(r.Header.Get("group"), Equals, "g1")
+}

--- a/samlsp/middleware_test.go
+++ b/samlsp/middleware_test.go
@@ -452,8 +452,12 @@ func (test *MiddlewareTest) TestHandlesInvalidResponse(c *C) {
 
 func (test *MiddlewareTest) TestHandlesInvalidClaimName(c *C) {
 	tc := TokenClaims{}
-	tc.Attributes = map[string][]string{"http://claim.com/claims/group": []string{"g1"}}
-	r := &http.Request{}
+	tc.Attributes = make(map[string][]string)
+	tc.Attributes["http://claim.com/claims/group"] = []string{"g1"}
+	http.NewRequest(
+	r := &http.Request{
+		Header: make(http.Header),
+	}
 	tc.SetHTTPHeader(r)
 	c.Assert(r.Header.Get("group"), Equals, "g1")
 }

--- a/service_provider.go
+++ b/service_provider.go
@@ -36,6 +36,7 @@ const (
 	UnspecifiedNameIDFormat  NameIDFormat = "urn:oasis:names:tc:SAML:2.0:nameid-format:unspecified"
 	TransientNameIDFormat    NameIDFormat = "urn:oasis:names:tc:SAML:2.0:nameid-format:transient"
 	EmailAddressNameIDFormat NameIDFormat = "urn:oasis:names:tc:SAML:2.0:nameid-format:emailAddress"
+	PersistentNameIDFormat   NameIDForamt = "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent"
 )
 
 // ServiceProvider implements SAML Service provider.

--- a/service_provider.go
+++ b/service_provider.go
@@ -36,7 +36,7 @@ const (
 	UnspecifiedNameIDFormat  NameIDFormat = "urn:oasis:names:tc:SAML:2.0:nameid-format:unspecified"
 	TransientNameIDFormat    NameIDFormat = "urn:oasis:names:tc:SAML:2.0:nameid-format:transient"
 	EmailAddressNameIDFormat NameIDFormat = "urn:oasis:names:tc:SAML:2.0:nameid-format:emailAddress"
-	PersistentNameIDFormat   NameIDForamt = "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent"
+	PersistentNameIDFormat   NameIDFormat = "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent"
 )
 
 // ServiceProvider implements SAML Service provider.


### PR DESCRIPTION
Only use the last element of claim names.  Some claims from Microsoft ADFS servers can contain a full url as the name, which is invalid for http headers