### PR TITLE
Fix testshib identity provider parsing

### DIFF
--- a/samlsp/samlsp.go
+++ b/samlsp/samlsp.go
@@ -103,7 +103,7 @@ func New(opts Options) (*Middleware, error) {
 			err = fmt.Errorf("no entity found with IDPSSODescriptor")
 			for _, e := range entities.EntityDescriptors {
 				if len(e.IDPSSODescriptors) > 0 {
-					entity = &e
+					*entity = e
 					err = nil
 				}
 			}

--- a/samlsp/samlsp_test.go
+++ b/samlsp/samlsp_test.go
@@ -448,8 +448,10 @@ func (test *ParseTest) TestCanParseTestshibMetadata(c *C) {
 	})
 
 	u := mustParseURL("https://idp.testshib.org/idp/shibboleth")
-	_, err := New(Options{IDPMetadataURL: &u})
+	m, err := New(Options{IDPMetadataURL: &u})
 	c.Assert(err, IsNil)
+	c.Assert(m.ServiceProvider.IDPMetadata.EntityID, Equals, "https://idp.testshib.org/idp/shibboleth")
+	c.Assert(len(m.ServiceProvider.IDPMetadata.IDPSSODescriptors), Equals, 1)
 }
 
 func (test *ParseTest) TestCanParseGoogleMetadata(c *C) {


### PR DESCRIPTION
`EntitiesDescriptor` has `EntityDescriptors` as plain `[]EntityDescriptor`

Therefore, when declaring `_, e := range entities.EntityDescriptors`, e is a
straight EntityDescriptor, it has a constant pointer.

The assignment `entity = &e`, has the same effect, storing the same
pointer each time.

However, the values of each `EntityDescriptor` is
copied from each array value to `e`, or `entity`, `e` and `entity`
pointing to the same address in memory.

This results in `m.ServiceProvider.IDPMetadata` to always have the latest
value of `EntityDescriptors` even if `len(e.IDPSSODescriptors) == 0`.

Signed-off-by: Thibault Jamet <tjamet@users.noreply.github.com>