### PR TITLE
expose ForceAuthn

### DIFF
--- a/samlsp/samlsp.go
+++ b/samlsp/samlsp.go
@@ -27,6 +27,7 @@ type Options struct {
 	IDPMetadataURL    *url.URL
 	HTTPClient        *http.Client
 	CookieMaxAge      time.Duration
+	ForceAuthn        bool
 }
 
 // New creates a new Middleware
@@ -54,6 +55,7 @@ func New(opts Options) (*Middleware, error) {
 			MetadataURL: metadataURL,
 			AcsURL:      acsURL,
 			IDPMetadata: opts.IDPMetadata,
+			ForceAuthn:  &opts.ForceAuthn,
 		},
 		AllowIDPInitiated: opts.AllowIDPInitiated,
 		CookieName:        defaultCookieName,

--- a/service_provider.go
+++ b/service_provider.go
@@ -76,6 +76,10 @@ type ServiceProvider struct {
 
 	// Logger is used to log messages for example in the event of errors
 	Logger logger.Interface
+
+	// ForceAuthn allows you to force re-authentication of users even if the user
+	// has a SSO session at the IdP.
+	ForceAuthn *bool
 }
 
 // MaxIssueDelay is the longest allowed time between when a SAML assertion is
@@ -274,6 +278,7 @@ func (sp *ServiceProvider) MakeAuthenticationRequest(idpURL string) (*AuthnReque
 			// urn:oasis:names:tc:SAML:2.0:nameid-format:transient
 			Format: &nameIDFormat,
 		},
+		ForceAuthn: sp.ForceAuthn,
 	}
 	return &req, nil
 }


### PR DESCRIPTION
Expose ForceAuthn in the SP options so consumers can require authentication from the IDP, even if an existing IDP session exists.