### PR TITLE
Add samlsp.Middleware.SecureCookie option

### DIFF
--- a/samlsp/middleware.go
+++ b/samlsp/middleware.go
@@ -53,6 +53,7 @@ type Middleware struct {
 	CookieName        string
 	CookieMaxAge      time.Duration
 	CookieDomain      string
+	CookieSecure      bool
 }
 
 const defaultCookieMaxAge = time.Hour
@@ -151,7 +152,7 @@ func (m *Middleware) RequireAccount(handler http.Handler) http.Handler {
 			Value:    signedState,
 			MaxAge:   int(saml.MaxIssueDelay.Seconds()),
 			HttpOnly: true,
-			Secure:   r.URL.Scheme == "https",
+			Secure:   m.CookieSecure || r.URL.Scheme == "https",
 			Path:     m.ServiceProvider.AcsURL.Path,
 		})
 
@@ -283,7 +284,7 @@ func (m *Middleware) Authorize(w http.ResponseWriter, r *http.Request, assertion
 		Value:    signedToken,
 		MaxAge:   int(m.CookieMaxAge.Seconds()),
 		HttpOnly: true,
-		Secure:   r.URL.Scheme == "https",
+		Secure:   m.CookieSecure || r.URL.Scheme == "https",
 		Path:     "/",
 	})
 

--- a/samlsp/samlsp.go
+++ b/samlsp/samlsp.go
@@ -27,6 +27,7 @@ type Options struct {
 	IDPMetadataURL    *url.URL
 	HTTPClient        *http.Client
 	CookieMaxAge      time.Duration
+	CookieSecure      bool
 	ForceAuthn        bool
 }
 
@@ -61,6 +62,7 @@ func New(opts Options) (*Middleware, error) {
 		CookieName:        defaultCookieName,
 		CookieMaxAge:      cookieMaxAge,
 		CookieDomain:      opts.URL.Host,
+		CookieSecure:      opts.CookieSecure,
 	}
 
 	// fetch the IDP metadata if needed.


### PR DESCRIPTION
Currently, the SAML middleware uses a secure cookie if the scheme of the authenticating HTTP request is "HTTPS". However, in some cases, an outer HTTP middleware handler will strip the request of its host/scheme, resulting in a non-secure cookie being used even if the web service is actually using HTTPS.

This PR adds the option to require secure cookies in `samlsp.New` by setting `SecureCookie: true`. It adds a test that checks that the "Secure" field is set in the HTTP authentication response.