### PR TITLE
samlsp: move signing JWT into an interface

### DIFF
--- a/samlsp/middleware_test.go
+++ b/samlsp/middleware_test.go
@@ -77,12 +77,18 @@ func (test *MiddlewareTest) SetUpTest(c *C) {
 		},
 		TokenMaxAge: time.Hour * 2,
 	}
+
 	cookieStore := ClientCookies{
 		ServiceProvider: &test.Middleware.ServiceProvider,
 		Name:            "ttt",
 	}
 	test.Middleware.ClientState = &cookieStore
 	test.Middleware.ClientToken = &cookieStore
+	test.Middleware.TokenSigner = &JWTTokenSigner{
+		Key:      x509.MarshalPKCS1PrivateKey(test.Middleware.ServiceProvider.Key),
+		Audience: test.Middleware.ServiceProvider.Metadata().EntityID,
+	}
+
 	err := xml.Unmarshal([]byte(test.IDPMetadata), &test.Middleware.ServiceProvider.IDPMetadata)
 	c.Assert(err, IsNil)
 }

--- a/samlsp/samlsp.go
+++ b/samlsp/samlsp.go
@@ -63,6 +63,13 @@ func New(opts Options) (*Middleware, error) {
 		TokenMaxAge:       tokenMaxAge,
 	}
 
+	if opts.Key != nil {
+		m.TokenSigner = &JWTTokenSigner{
+			Key:      x509.MarshalPKCS1PrivateKey(opts.Key),
+			Audience: m.ServiceProvider.Metadata().EntityID,
+		}
+	}
+
 	cookieStore := ClientCookies{
 		ServiceProvider: &m.ServiceProvider,
 		Name:            defaultCookieName,

--- a/samlsp/token_signer.go
+++ b/samlsp/token_signer.go
@@ -1,0 +1,57 @@
+package samlsp
+
+import (
+	"context"
+	"fmt"
+
+	jwt "github.com/dgrijalva/jwt-go"
+)
+
+// AuthorizationTokenSigner implements signing for authorization tokens
+type AuthorizationTokenSigner interface {
+	// ParseAuthorizationToken returns an authorization token if tokenStr is a valid serialized token
+	// produced by MarshalAuthorizationToken.
+	ParseAuthorizationToken(ctx context.Context, tokenStr string) (*AuthorizationToken, error)
+
+	// MarshalAuthorizationToken marshals and signs the token returning the serialized token
+	MarshalAuthorizationToken(ctx context.Context, token AuthorizationToken) (string, error)
+}
+
+// JWTTokenSigner implements AuthorizationTokenSigner using JWT
+type JWTTokenSigner struct {
+	Key      []byte
+	Audience string
+}
+
+// ParseAuthorizationToken returns a token from a JWT encoded & signed token.
+func (j JWTTokenSigner) ParseAuthorizationToken(ctx context.Context, tokenStr string) (*AuthorizationToken, error) {
+	claims := AuthorizationToken{}
+	token, err := jwt.ParseWithClaims(tokenStr, &claims, func(t *jwt.Token) (interface{}, error) {
+		return j.Key, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	if !token.Valid {
+		return nil, fmt.Errorf("invalid token")
+	}
+
+	if err := claims.StandardClaims.Valid(); err != nil {
+		return nil, err
+	}
+
+	if claims.Audience != j.Audience {
+		return nil, fmt.Errorf("incorrect audience: %v", claims.Audience)
+	}
+
+	return &claims, nil
+}
+
+// MarshalAuthorizationToken marshals and signs the token returning the serialized token
+func (j JWTTokenSigner) MarshalAuthorizationToken(ctx context.Context, token AuthorizationToken) (string, error) {
+	signedToken, err := jwt.NewWithClaims(jwt.SigningMethodHS256, token).SignedString(j.Key)
+	if err != nil {
+		return "", err
+	}
+	return signedToken, nil
+}


### PR DESCRIPTION
We’ve had a bunch of changes requesting the ability to customize
how cookies are set and it is getting a little messy. This change
moves the code to setting and reading cookies into two interfaces
which you can extend/customize.