### PR TITLE
Test for XML canonicalization vuln

### DIFF
--- a/schema_test.go
+++ b/schema_test.go
@@ -34,3 +34,33 @@ func (test *SchemaTest) TestAttributeXMLRoundTrip(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(actual, DeepEquals, expected)
 }
+
+func compare(c *C, doc *etree.Document, input string, expected string) {
+	elem := doc.SelectElement("saml:Attribute")
+	// fails to parse with the evil injection unescaped (nil)
+	if elem != nil {
+		actual := elem.SelectAttr("Name")
+		c.Assert(actual.Value, Equals, expected)
+	}
+}
+
+func (test *SchemaTest) TestXMLCanonicalizationVuln(c *C) {
+	maliciousInputUnescaped := "<saml:Attribute FriendlyName=\"TestFriendlyName\" Name=\"user.com<!-- vuln if substring returns -->evil.com\" NameFormat=\"urn:oasis:names:tc:SAML:2.0:attrname-format:basic\"><saml:AttributeValue xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xs=\"http://www.w3.org/2001/XMLSchema\" xsi:type=\"xs:string\">test</saml:AttributeValue></saml:Attribute>"
+	maliciousInputEscaped := "<saml:Attribute FriendlyName=\"TestFriendlyName\" Name=\"user.com&lt;!-- vuln if substring returns --&gt;evil.com\" NameFormat=\"urn:oasis:names:tc:SAML:2.0:attrname-format:basic\"><saml:AttributeValue xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xs=\"http://www.w3.org/2001/XMLSchema\" xsi:type=\"xs:string\">test</saml:AttributeValue></saml:Attribute>"
+	expected := "user.com<!-- vuln if substring returns -->evil.com"
+
+	// without canonicalization
+	doc := etree.NewDocument()
+	compare(c, doc, maliciousInputUnescaped, expected)
+	compare(c, doc, maliciousInputEscaped, expected)
+
+	// with canonicalization
+	doc = etree.NewDocument()
+	doc.WriteSettings = etree.WriteSettings{
+		CanonicalAttrVal: true,
+		CanonicalEndTags: true,
+		CanonicalText:    true,
+	}
+	compare(c, doc, maliciousInputUnescaped, expected)
+	compare(c, doc, maliciousInputEscaped, expected)
+}


### PR DESCRIPTION
I see you beat me by a couple of hours in https://github.com/crewjam/saml/commit/814d1d9c18457deeda08cbda2d38f79bedccfa62 , which is pretty great.

I did a bit lower level approach, testing canonicalization on/off with retrieving an attribute using etree. Including the PR if you'd like to include this as well.