### PR TITLE
Fix AES decryption

### DIFF
--- a/service_provider.go
+++ b/service_provider.go
@@ -463,8 +463,18 @@ func (sp *ServiceProvider) ParseResponse(req *http.Request, possibleRequestIDs [
 			retErr.PrivateErr = err
 			return nil, retErr
 		}
+		var key interface{} = sp.Key
+		keyEl := doc.FindElement("//EncryptedAssertion/EncryptedKey")
+		if keyEl != nil {
+			key, err = xmlenc.Decrypt(sp.Key, keyEl)
+			if err != nil {
+				retErr.PrivateErr = fmt.Errorf("failed to decrypt key from response: %s", err)
+				return nil, retErr
+			}
+		}
+
 		el := doc.FindElement("//EncryptedAssertion/EncryptedData")
-		plaintextAssertion, err := xmlenc.Decrypt(sp.Key, el)
+		plaintextAssertion, err := xmlenc.Decrypt(key, el)
 		if err != nil {
 			retErr.PrivateErr = fmt.Errorf("failed to decrypt response: %s", err)
 			return nil, retErr


### PR DESCRIPTION
Fix AES decryption by decrypting the EncryptedKey from the response, and passing
the decrypted key to the data decryption.

This addresses #135.