### PR TITLE
Changes for Ping Federate implementation

### DIFF
--- a/samlsp/middleware.go
+++ b/samlsp/middleware.go
@@ -215,6 +215,10 @@ func (m *Middleware) Authorize(w http.ResponseWriter, r *http.Request, assertion
 			return
 		}
 		claims := state.Claims.(jwt.MapClaims)
+		if claims == nil {
+			http.Error(w, http.StatusText(http.StatusForbidden), http.StatusForbidden)
+			return
+		}
 		redirectURI = claims["uri"].(string)
 
 		// delete the cookie

--- a/schema.go
+++ b/schema.go
@@ -160,13 +160,12 @@ func (a *Issuer) Element() *etree.Element {
 }
 
 // NameIDPolicy represents the SAML object of the same name.
-//
-// See http://docs.oasis-open.org/security/saml/v2.0/saml-core-2.0-os.pdf
+//PingIDP changes: mattbird library
 type NameIDPolicy struct {
 	XMLName         xml.Name `xml:"urn:oasis:names:tc:SAML:2.0:protocol NameIDPolicy"`
-	Format          *string  `xml:",attr"`
+	Format          *string  `xml:"Format,attr"`
 	SPNameQualifier *string  `xml:",attr"`
-	AllowCreate     *bool    `xml:",attr"`
+	AllowCreate     *bool    `xml:"AllowCreate,attr"`
 }
 
 // Element returns an etree.Element representing the object in XML form.

--- a/service_provider.go
+++ b/service_provider.go
@@ -275,6 +275,9 @@ func (sp *ServiceProvider) MakeAuthenticationRequest(idpURL string) (*AuthnReque
 			Value:  sp.MetadataURL.String(),
 		},
 		NameIDPolicy: &NameIDPolicy{
+			XMLName: xml.Name{
+				Local: "NameIDPolicy",
+			},
 			AllowCreate: &allowCreate,
 			// TODO(ross): figure out exactly policy we need
 			// urn:mace:shibboleth:1.0:nameIdentifier


### PR DESCRIPTION
This library as it is worked for shibboleth implementation, but for Ping, the json tags in schema.go had to be changed for 2 fields. This PR includes that change along with an additional check to avoid nil pointer dereference, I had come across it while debugging. 