### PR TITLE
Return nameID in session

### DIFF
--- a/samlidp/session.go
+++ b/samlidp/session.go
@@ -57,6 +57,7 @@ func (s *Server) GetSession(w http.ResponseWriter, r *http.Request, req *saml.Id
 			UserCommonName: user.CommonName,
 			UserSurname:    user.Surname,
 			UserGivenName:  user.GivenName,
+			NameID:         user.Name,
 		}
 		if err := s.Store.Put(fmt.Sprintf("/sessions/%s", session.ID), &session); err != nil {
 			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)


### PR DESCRIPTION
An empty nameID was returned.  This PR always send user.Name as the nameID.  In the future we can allow some configuration so a different nameID will be returned.