### PR TITLE
Make Certificate optional for ServiceProvider.Metadata()

### DIFF
--- a/service_provider.go
+++ b/service_provider.go
@@ -109,6 +109,29 @@ func (sp *ServiceProvider) Metadata() *EntityDescriptor {
 	authnRequestsSigned := false
 	wantAssertionsSigned := true
 	validUntil := TimeNow().Add(validDuration)
+	var keyDescriptors []KeyDescriptor
+	if sp.Certificate != nil {
+		keyDescriptors = []KeyDescriptor{
+			{
+				Use: "signing",
+				KeyInfo: KeyInfo{
+					Certificate: base64.StdEncoding.EncodeToString(sp.Certificate.Raw),
+				},
+			},
+			{
+				Use: "encryption",
+				KeyInfo: KeyInfo{
+					Certificate: base64.StdEncoding.EncodeToString(sp.Certificate.Raw),
+				},
+				EncryptionMethods: []EncryptionMethod{
+					{Algorithm: "http://www.w3.org/2001/04/xmlenc#aes128-cbc"},
+					{Algorithm: "http://www.w3.org/2001/04/xmlenc#aes192-cbc"},
+					{Algorithm: "http://www.w3.org/2001/04/xmlenc#aes256-cbc"},
+					{Algorithm: "http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p"},
+				},
+			},
+		}
+	}
 	return &EntityDescriptor{
 		EntityID:   sp.MetadataURL.String(),
 		ValidUntil: validUntil,
@@ -118,27 +141,8 @@ func (sp *ServiceProvider) Metadata() *EntityDescriptor {
 				SSODescriptor: SSODescriptor{
 					RoleDescriptor: RoleDescriptor{
 						ProtocolSupportEnumeration: "urn:oasis:names:tc:SAML:2.0:protocol",
-						KeyDescriptors: []KeyDescriptor{
-							{
-								Use: "signing",
-								KeyInfo: KeyInfo{
-									Certificate: base64.StdEncoding.EncodeToString(sp.Certificate.Raw),
-								},
-							},
-							{
-								Use: "encryption",
-								KeyInfo: KeyInfo{
-									Certificate: base64.StdEncoding.EncodeToString(sp.Certificate.Raw),
-								},
-								EncryptionMethods: []EncryptionMethod{
-									{Algorithm: "http://www.w3.org/2001/04/xmlenc#aes128-cbc"},
-									{Algorithm: "http://www.w3.org/2001/04/xmlenc#aes192-cbc"},
-									{Algorithm: "http://www.w3.org/2001/04/xmlenc#aes256-cbc"},
-									{Algorithm: "http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p"},
-								},
-							},
-						},
-						ValidUntil: validUntil,
+						KeyDescriptors:             keyDescriptors,
+						ValidUntil:                 validUntil,
 					},
 				},
 				AuthnRequestsSigned:  &authnRequestsSigned,

--- a/service_provider_test.go
+++ b/service_provider_test.go
@@ -140,6 +140,25 @@ func (test *ServiceProviderTest) TestCanProduceMetadata(c *C) {
 		"</EntityDescriptor>")
 }
 
+func (test *ServiceProviderTest) TestCanProduceMetadataNoSigningKey(c *C) {
+	s := ServiceProvider{
+		MetadataURL: mustParseURL("https://example.com/saml2/metadata"),
+		AcsURL:      mustParseURL("https://example.com/saml2/acs"),
+		IDPMetadata: &EntityDescriptor{},
+	}
+	err := xml.Unmarshal([]byte(test.IDPMetadata), &s.IDPMetadata)
+	c.Assert(err, IsNil)
+
+	spMetadata, err := xml.MarshalIndent(s.Metadata(), "", "  ")
+	c.Assert(err, IsNil)
+	c.Assert(string(spMetadata), DeepEquals, ""+
+		"<EntityDescriptor xmlns=\"urn:oasis:names:tc:SAML:2.0:metadata\" validUntil=\"2015-12-03T01:57:09Z\" entityID=\"https://example.com/saml2/metadata\">\n"+
+		"  <SPSSODescriptor xmlns=\"urn:oasis:names:tc:SAML:2.0:metadata\" validUntil=\"2015-12-03T01:57:09Z\" protocolSupportEnumeration=\"urn:oasis:names:tc:SAML:2.0:protocol\" AuthnRequestsSigned=\"false\" WantAssertionsSigned=\"true\">\n"+
+		"    <AssertionConsumerService Binding=\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST\" Location=\"https://example.com/saml2/acs\" index=\"1\"></AssertionConsumerService>\n"+
+		"  </SPSSODescriptor>\n"+
+		"</EntityDescriptor>")
+}
+
 func (test *ServiceProviderTest) TestCanProduceRedirectRequest(c *C) {
 	TimeNow = func() time.Time {
 		rv, _ := time.Parse("Mon Jan 2 15:04:05.999999999 UTC 2006", "Mon Dec 1 01:31:21.123456789 UTC 2015")


### PR DESCRIPTION
Hi Ross, thanks for taking the time to review this PR! Please let me know if there's another process you'd prefer I use to get in touch with you.

This makes the `<KeyDescriptor>` elements generated by `ServiceProvider.Metadata()` optional. `ServiceProvider` doesn't need keys for `MakeAuthenticationRequest()` or `ParseResponse()`, and AFAICT `Metadata()` is the only method that requires them. This PR removes that requirement, so that a `ServiceProvider` without keys can be used for all SAML endpoints.