### PR TITLE
Set session NameID based on email

### DIFF
--- a/samlidp/session.go
+++ b/samlidp/session.go
@@ -48,6 +48,7 @@ func (s *Server) GetSession(w http.ResponseWriter, r *http.Request, req *saml.Id
 
 		session := &saml.Session{
 			ID:             base64.StdEncoding.EncodeToString(randomBytes(32)),
+			NameID:         user.Email,
 			CreateTime:     saml.TimeNow(),
 			ExpireTime:     saml.TimeNow().Add(sessionMaxAge),
 			Index:          hex.EncodeToString(randomBytes(32)),


### PR DESCRIPTION
The subject's `NameID` is [fetched from the session](https://github.com/crewjam/saml/blob/master/identity_provider.go#L661) but that value is never set.

This PR uses the email value to set this field too.