### PR TITLE
add support to service provider for IDP with multiple signing certs

### DIFF
--- a/service_provider.go
+++ b/service_provider.go
@@ -239,7 +239,6 @@ func (sp *ServiceProvider) getIDPSigningCerts() ([]*x509.Certificate, error) {
 	// cleanup whitespace
 	regex := regexp.MustCompile(`\s+`)
 	for _, certStr := range certStrs {
-		// cleanup whitespace
 		certStr = regex.ReplaceAllString(certStr, "")
 		certBytes, err := base64.StdEncoding.DecodeString(certStr)
 		if err != nil {


### PR DESCRIPTION
I encountered an issue where the IDP (ADFS) was publishing two signing certificates during a rollover period of the certificate.