### PR TITLE
Prevent panic caused by IDP-initiated login

### DIFF
--- a/samlsp/middleware.go
+++ b/samlsp/middleware.go
@@ -183,13 +183,13 @@ func (m *Middleware) getPossibleRequestIDs(r *http.Request) []string {
 			m.ServiceProvider.Logger.Printf("... invalid token %s", err)
 			continue
 		}
+		// If IDP initiated requests are allowed, then we can expect an empty response ID.
 		claims := token.Claims.(jwt.MapClaims)
 		if id, ok := claims["id"]; ok {
 			rv = append(rv, id.(string))
 		}
 	}
 
-	// If IDP initiated requests are allowed, then we can expect an empty response ID.
 	if m.AllowIDPInitiated {
 		rv = append(rv, "")
 	}
@@ -206,33 +206,28 @@ func (m *Middleware) Authorize(w http.ResponseWriter, r *http.Request, assertion
 	redirectURI := "/"
 	if relayState := r.Form.Get("RelayState"); relayState != "" {
 		stateValue := m.ClientState.GetState(r, relayState)
-		if stateValue != "" {
-			jwtParser := jwt.Parser{
-				ValidMethods: []string{jwtSigningMethod.Name},
-			}
-			state, err := jwtParser.Parse(stateValue, func(t *jwt.Token) (interface{}, error) {
-				return secretBlock, nil
-			})
-			if err != nil || !state.Valid {
-				m.ServiceProvider.Logger.Printf("Cannot decode state JWT: %s (%s)", err, stateValue)
-				http.Error(w, http.StatusText(http.StatusForbidden), http.StatusForbidden)
-				return
-			}
-			claims := state.Claims.(jwt.MapClaims)
-			redirectURI = claims["uri"].(string)
-
-			// delete the cookie
-			m.ClientState.DeleteState(w, r, relayState)
-		} else if m.AllowIDPInitiated {
-			// If the state value couldn't be retrieved for the RelayState, and IDP-initiated flows are allowed
-			// then use the RelayState value as the redirect URI itself.
-			redirectURI = relayState
-		} else {
-			// Otherwise, redirect the user with a 403.
+		if stateValue == "" {
 			m.ServiceProvider.Logger.Printf("cannot find corresponding state: %s", relayState)
 			http.Error(w, http.StatusText(http.StatusForbidden), http.StatusForbidden)
 			return
 		}
+
+		jwtParser := jwt.Parser{
+			ValidMethods: []string{jwtSigningMethod.Name},
+		}
+		state, err := jwtParser.Parse(stateValue, func(t *jwt.Token) (interface{}, error) {
+			return secretBlock, nil
+		})
+		if err != nil || !state.Valid {
+			m.ServiceProvider.Logger.Printf("Cannot decode state JWT: %s (%s)", err, stateValue)
+			http.Error(w, http.StatusText(http.StatusForbidden), http.StatusForbidden)
+			return
+		}
+		claims := state.Claims.(jwt.MapClaims)
+		redirectURI = claims["uri"].(string)
+
+		// delete the cookie
+		m.ClientState.DeleteState(w, r, relayState)
 	}
 
 	now := saml.TimeNow()


### PR DESCRIPTION
There are two changes in this PR to support IDP-initiated logins. The first one is to prevent a panic for IDP-initiated logins. The second, is so that IDP-initiated logins will properly redirect the user.

- No request ID claim in the `ClientState`(s) when a SAML assertion is POST'ed directly to the SP's ACS URL. So I've added a guard to check if the `ClientState` has such a claim and not assume it will.
- When the SAML app configuration has a "Default Relay State" (Okta) or a "Start URL" (GSuite), it is actually a URL-encoded value, that is considered to be a deep-link. With that in mind, in an IDP-initiated login, the incoming `RelayState` value will not correspond to any known cookies in the client's cookie store. Hence, we can use the `RelayState` value as the `redirectURI`, but only if the `AllowIDPInitiated` flag is true, AND if we couldn't find a "state value" using that `RelayState` value.

This may "fix" #151 (I put it in quotes so GitHub doesn't auto-close that issue).
