### PR TITLE
omit validUntil if empty 

### DIFF
--- a/metadata.go
+++ b/metadata.go
@@ -133,7 +133,7 @@ type ContactPerson struct {
 // See http://docs.oasis-open.org/security/saml/v2.0/saml-metadata-2.0-os.pdf §2.4.1
 type RoleDescriptor struct {
 	ID                         string        `xml:",attr,omitempty"`
-	ValidUntil                 time.Time     `xml:"validUntil,attr,omitempty"`
+	ValidUntil                 *time.Time    `xml:"validUntil,attr,omitempty"`
 	CacheDuration              time.Duration `xml:"cacheDuration,attr,omitempty"`
 	ProtocolSupportEnumeration string        `xml:"protocolSupportEnumeration,attr"`
 	ErrorURL                   string        `xml:"errorURL,attr,omitempty"`

--- a/metadata_test.go
+++ b/metadata_test.go
@@ -153,7 +153,7 @@ cvCsEFiJZ4AbF+DgmO6TarJ8O05t8zvnOwJlNCASPZRH/JmF8tX0hoHuAQ==`,
 	c.Assert(err, IsNil)
 	c.Assert(string(buf), Equals, ""+
 		"<EntityDescriptor xmlns=\"urn:oasis:names:tc:SAML:2.0:metadata\" validUntil=\"2013-03-10T00:32:19.104Z\" cacheDuration=\"PT1H\" entityID=\"http://localhost:5000/e087a985171710fb9fb30f30f41384f9/saml2/metadata/\">\n"+
-		"  <SPSSODescriptor xmlns=\"urn:oasis:names:tc:SAML:2.0:metadata\" validUntil=\"0001-01-01T00:00:00Z\" protocolSupportEnumeration=\"urn:oasis:names:tc:SAML:2.0:protocol\" AuthnRequestsSigned=\"true\" WantAssertionsSigned=\"true\">\n"+
+		"  <SPSSODescriptor xmlns=\"urn:oasis:names:tc:SAML:2.0:metadata\" protocolSupportEnumeration=\"urn:oasis:names:tc:SAML:2.0:protocol\" AuthnRequestsSigned=\"true\" WantAssertionsSigned=\"true\">\n"+
 		"    <KeyDescriptor use=\"encryption\">\n"+
 		"      <KeyInfo xmlns=\"http://www.w3.org/2000/09/xmldsig#\">\n"+
 		"        <X509Data>\n"+

--- a/service_provider.go
+++ b/service_provider.go
@@ -138,7 +138,7 @@ func (sp *ServiceProvider) Metadata() *EntityDescriptor {
 								},
 							},
 						},
-						ValidUntil: validUntil,
+						ValidUntil: &validUntil,
 					},
 				},
 				AuthnRequestsSigned:  &authnRequestsSigned,


### PR DESCRIPTION
Some SAML libraries like simplesamlphp view the validUntil as expired on the SPSSODescriptor  when zero'ed out. 

The patch omits it if not set.
