### PR TITLE
#192: Support multiple IdP signing certificates

### DIFF
--- a/duration_test.go
+++ b/duration_test.go
@@ -72,7 +72,12 @@ func (t DurationTest) TestUnmarshalText(c *C) {
 	for _, tc := range durationUnmarshalTests {
 		var d Duration
 		err := d.UnmarshalText(tc.in)
-		c.Assert(err, DeepEquals, tc.err)
+		if tc.err == nil {
+			c.Assert(err, IsNil)
+		} else {
+			c.Assert(err, NotNil)
+			c.Assert(err.Error(), Equals, tc.err.Error())
+		}
 		c.Assert(d, Equals, Duration(tc.out))
 	}
 }


### PR DESCRIPTION
This change updates `service_provider.go` to create an array of signing certificates from all those found in the IdP metadata.  Issue #192 has details about why this is necessary.

Connected to #192