### PR TITLE
#194: Properly default EncryptionMethod/DigestMethod

### DIFF
--- a/xmlenc/pubkey.go
+++ b/xmlenc/pubkey.go
@@ -107,14 +107,15 @@ func (e RSA) Decrypt(key interface{}, ciphertextEl *etree.Element) ([]byte, erro
 	{
 		digestMethodEl := ciphertextEl.FindElement("./EncryptionMethod/DigestMethod")
 		if digestMethodEl == nil {
-			return nil, fmt.Errorf("cannot find required DigestMethod element")
+			e.DigestMethod = SHA1
+		} else {
+			hashAlgorithmStr := digestMethodEl.SelectAttrValue("Algorithm", "")
+			digestMethod, ok := digestMethods[hashAlgorithmStr]
+			if !ok {
+				return nil, ErrAlgorithmNotImplemented(hashAlgorithmStr)
+			}
+			e.DigestMethod = digestMethod
 		}
-		hashAlgorithmStr := digestMethodEl.SelectAttrValue("Algorithm", "")
-		digestMethod, ok := digestMethods[hashAlgorithmStr]
-		if !ok {
-			return nil, ErrAlgorithmNotImplemented(hashAlgorithmStr)
-		}
-		e.DigestMethod = digestMethod
 	}
 
 	return e.keyDecrypter(e, rsaKey, ciphertext)


### PR DESCRIPTION
The absence of a digest method was considered an error whereas the spec implies that it should default SHA1.

See #194