### PR TITLE
#198: Allow AudienceRestriction to be missing.

### DIFF
--- a/service_provider.go
+++ b/service_provider.go
@@ -549,7 +549,7 @@ func (sp *ServiceProvider) validateAssertion(assertion *Assertion, possibleReque
 		return fmt.Errorf("Conditions is expired")
 	}
 
-	audienceRestrictionsValid := false
+	audienceRestrictionsValid := len(assertion.Conditions.AudienceRestrictions) == 0
 	for _, audienceRestriction := range assertion.Conditions.AudienceRestrictions {
 		if audienceRestriction.Audience.Value == sp.MetadataURL.String() {
 			audienceRestrictionsValid = true

--- a/service_provider_test.go
+++ b/service_provider_test.go
@@ -786,9 +786,10 @@ func (test *ServiceProviderTest) TestInvalidAssertions(c *C) {
 	assertion = Assertion{}
 	xml.Unmarshal(assertionBuf, &assertion)
 
+	// Not having an audience is not an error
 	assertion.Conditions.AudienceRestrictions = []AudienceRestriction{}
 	err = s.validateAssertion(&assertion, []string{"id-9e61753d64e928af5a7a341a97f420c9"}, TimeNow())
-	c.Assert(err.Error(), Equals, nil)
+	c.Assert(err, Equals, nil)
 }
 
 func (test *ServiceProviderTest) TestRealWorldKeyInfoHasRSAPublicKeyNotX509Cert(c *C) {

--- a/service_provider_test.go
+++ b/service_provider_test.go
@@ -785,6 +785,10 @@ func (test *ServiceProviderTest) TestInvalidAssertions(c *C) {
 	c.Assert(err.Error(), Equals, "Conditions AudienceRestriction does not contain \"https://15661444.ngrok.io/saml2/metadata\"")
 	assertion = Assertion{}
 	xml.Unmarshal(assertionBuf, &assertion)
+
+	assertion.Conditions.AudienceRestrictions = []AudienceRestriction{}
+	err = s.validateAssertion(&assertion, []string{"id-9e61753d64e928af5a7a341a97f420c9"}, TimeNow())
+	c.Assert(err.Error(), Equals, nil)
 }
 
 func (test *ServiceProviderTest) TestRealWorldKeyInfoHasRSAPublicKeyNotX509Cert(c *C) {


### PR DESCRIPTION
This change allows the `<AudienceRestriction>` element to be missing in a SAML response.

See #198 on why this is not a security problem.