### PR TITLE
Don't include the port with the domain when setting the cookie

### DIFF
--- a/samlsp/cookie.go
+++ b/samlsp/cookie.go
@@ -1,6 +1,7 @@
 package samlsp
 
 import (
+	"net"
 	"net/http"
 	"strings"
 	"time"
@@ -84,7 +85,7 @@ func (c ClientCookies) SetToken(w http.ResponseWriter, r *http.Request, value st
 	// Cookies should not have the port attached to them so strip it off
 	domain := c.Domain
 	if strings.Contains(domain, ":") {
-		domain = strings.Split(domain, ":")[0]
+		domain, _, _ = net.SplitHostPort(domain)
 	}
 	http.SetCookie(w, &http.Cookie{
 		Name:     c.Name,

--- a/samlsp/cookie.go
+++ b/samlsp/cookie.go
@@ -81,9 +81,14 @@ func (c ClientCookies) DeleteState(w http.ResponseWriter, r *http.Request, id st
 
 // SetToken assigns the specified token by setting a cookie.
 func (c ClientCookies) SetToken(w http.ResponseWriter, r *http.Request, value string, maxAge time.Duration) {
+	// Cookies should not have the port attached to them so strip it off
+	domain := c.Domain
+	if strings.Contains(domain, ":") {
+		domain = strings.Split(domain, ":")[0]
+	}
 	http.SetCookie(w, &http.Cookie{
 		Name:     c.Name,
-		Domain:   c.Domain,
+		Domain:   domain,
 		Value:    value,
 		MaxAge:   int(maxAge.Seconds()),
 		HttpOnly: true,


### PR DESCRIPTION
When setting cookies, the port should not be included with the domain. The top answer to this question explains why:

<https://stackoverflow.com/questions/1612177/are-http-cookies-port-specific>

The net/http module automatically strips the port number off, this change just tidies up the code so it doesn't have to.

```
2019/05/14 22:31:13 net/http: invalid Cookie.Domain "localhost:8000"; dropping domain attribute
```