### PR TITLE
Don't require Destination attribute in response when response is not signed

### DIFF
--- a/service_provider.go
+++ b/service_provider.go
@@ -378,6 +378,39 @@ func (ivr *InvalidResponseError) Error() string {
 	return fmt.Sprintf("Authentication failed")
 }
 
+func responseContainsSignature(response *etree.Document) (bool, error) {
+	signatureElement, err := findChild(response.Root(), "http://www.w3.org/2000/09/xmldsig#", "Signature")
+	if err != nil {
+		return false, err
+	}
+	if signatureElement == nil {
+		return false, nil
+	}
+	return true, nil
+}
+
+func (sp *ServiceProvider) validateDestination(response []byte, responseDom *Response) error {
+	// A response MUST contain a Destination attribute if the SAML request is signed.
+	responseXml := etree.NewDocument()
+	err := responseXml.ReadFromBytes(response)
+	if err != nil {
+		return err
+	}
+
+	present, err := responseContainsSignature(responseXml)
+	if err != nil {
+		return err
+	}
+
+	if present {
+		if responseDom.Destination != sp.AcsURL.String() {
+			return fmt.Errorf("`Destination` does not match AcsURL (expected %q, actual %q)", sp.AcsURL.String(), responseDom.Destination)
+		}
+	}
+
+	return nil
+}
+
 // ParseResponse extracts the SAML IDP response received in req, validates
 // it, and returns the verified attributes of the request.
 //
@@ -409,8 +442,9 @@ func (sp *ServiceProvider) ParseResponse(req *http.Request, possibleRequestIDs [
 		retErr.PrivateErr = fmt.Errorf("cannot unmarshal response: %s", err)
 		return nil, retErr
 	}
-	if resp.Destination != sp.AcsURL.String() {
-		retErr.PrivateErr = fmt.Errorf("`Destination` does not match AcsURL (expected %q)", sp.AcsURL.String())
+
+	if err := sp.validateDestination(rawResponseBuf, &resp); err != nil {
+		retErr.PrivateErr = err
 		return nil, retErr
 	}
 

--- a/service_provider.go
+++ b/service_provider.go
@@ -386,7 +386,8 @@ func responseIsSigned(response *etree.Document) (bool, error) {
 	return signatureElement != nil, nil
 }
 
-// validateDestination validates the Destination attribute iff the response is signed.
+// validateDestination validates the Destination attribute.
+// If the response is signed, the Destination is required to be present.
 func (sp *ServiceProvider) validateDestination(response []byte, responseDom *Response) error {
 	responseXml := etree.NewDocument()
 	err := responseXml.ReadFromBytes(response)
@@ -399,7 +400,10 @@ func (sp *ServiceProvider) validateDestination(response []byte, responseDom *Res
 		return err
 	}
 
-	if signed {
+
+	// Compare if the response is signed OR the Destination is provided.
+	// (Even if the response is not signed, if the Destination is set it must match.)
+	if signed || responseDom.Destination != "" {
 		if responseDom.Destination != sp.AcsURL.String() {
 			return fmt.Errorf("`Destination` does not match AcsURL (expected %q, actual %q)", sp.AcsURL.String(), responseDom.Destination)
 		}

--- a/service_provider_test.go
+++ b/service_provider_test.go
@@ -17,7 +17,9 @@ import (
 
 	"crypto/x509"
 
+	"github.com/beevik/etree"
 	. "gopkg.in/check.v1"
+	"strings"
 )
 
 // Hook up gocheck into the "go test" runner.
@@ -642,6 +644,86 @@ func (test *ServiceProviderTest) TestCanParseResponse(c *C) {
 	})
 }
 
+func (test *ServiceProviderTest) TestCanProcessResponseWithoutDestination(c *C) {
+	s := ServiceProvider{
+		Key:         test.Key,
+		Certificate: test.Certificate,
+		MetadataURL: mustParseURL("https://15661444.ngrok.io/saml2/metadata"),
+		AcsURL:      mustParseURL("https://15661444.ngrok.io/saml2/acs"),
+		IDPMetadata: &EntityDescriptor{},
+	}
+	err := xml.Unmarshal([]byte(test.IDPMetadata), &s.IDPMetadata)
+	c.Assert(err, IsNil)
+
+	stripDestination := func(source string) (output string) {
+		return strings.Replace(source, "Destination=\"https://15661444.ngrok.io/saml2/acs\"", "", 1)
+	}
+
+	req := http.Request{PostForm: url.Values{}}
+	samlResponseWithoutDestination := stripDestination(test.SamlResponse)
+	req.PostForm.Set("SAMLResponse", base64.StdEncoding.EncodeToString([]byte(samlResponseWithoutDestination)))
+	_, err = s.ParseResponse(&req, []string{"id-9e61753d64e928af5a7a341a97f420c9"})
+	c.Assert(err, Equals, nil)
+}
+
+func (test *ServiceProviderTest) responseDom() (doc *etree.Document) {
+	doc = etree.NewDocument()
+	doc.ReadFromString(test.SamlResponse)
+	return doc
+}
+
+func addSignatureToDocument(doc *etree.Document) *etree.Document {
+	responseEl := doc.FindElement("//Response")
+	signatureEl := doc.CreateElement("xmldsig:Signature")
+	signatureEl.CreateAttr("xmlns:xmldsig", "http://www.w3.org/2000/09/xmldsig#")
+	responseEl.AddChild(signatureEl)
+	return doc
+}
+
+func removeDestinationFromDocument(doc *etree.Document) *etree.Document {
+	responseEl := doc.FindElement("//Response")
+	responseEl.RemoveAttr("Destination")
+	return doc
+}
+
+func (test *ServiceProviderTest) TestMismatchedDestinationsWithSignaturePresent(c *C) {
+	s := ServiceProvider{
+		Key:         test.Key,
+		Certificate: test.Certificate,
+		MetadataURL: mustParseURL("https://15661444.ngrok.io/saml2/metadata"),
+		AcsURL:      mustParseURL("https://15661444.ngrok.io/saml2/acs"),
+		IDPMetadata: &EntityDescriptor{},
+	}
+	err := xml.Unmarshal([]byte(test.IDPMetadata), &s.IDPMetadata)
+	c.Assert(err, IsNil)
+
+	req := http.Request{PostForm: url.Values{}}
+	s.AcsURL = mustParseURL("https://wrong/saml2/acs")
+	bytes, _ := addSignatureToDocument(test.responseDom()).WriteToBytes()
+	req.PostForm.Set("SAMLResponse", base64.StdEncoding.EncodeToString(bytes))
+	_, err = s.ParseResponse(&req, []string{"id-9e61753d64e928af5a7a341a97f420c9"})
+	c.Assert(err.(*InvalidResponseError).PrivateErr.Error(), Equals, "`Destination` does not match AcsURL (expected \"https://wrong/saml2/acs\", actual \"https://15661444.ngrok.io/saml2/acs\")")
+	s.AcsURL = mustParseURL("https://15661444.ngrok.io/saml2/acs")
+}
+
+func (test *ServiceProviderTest) TestMissingDestinationWithSignaturePresent(c *C) {
+	s := ServiceProvider{
+		Key:         test.Key,
+		Certificate: test.Certificate,
+		MetadataURL: mustParseURL("https://15661444.ngrok.io/saml2/metadata"),
+		AcsURL:      mustParseURL("https://15661444.ngrok.io/saml2/acs"),
+		IDPMetadata: &EntityDescriptor{},
+	}
+	err := xml.Unmarshal([]byte(test.IDPMetadata), &s.IDPMetadata)
+	c.Assert(err, IsNil)
+
+	req := http.Request{PostForm: url.Values{}}
+	bytes, _ := removeDestinationFromDocument(addSignatureToDocument(test.responseDom())).WriteToBytes()
+	req.PostForm.Set("SAMLResponse", base64.StdEncoding.EncodeToString(bytes))
+	_, err = s.ParseResponse(&req, []string{"id-9e61753d64e928af5a7a341a97f420c9"})
+	c.Assert(err.(*InvalidResponseError).PrivateErr.Error(), Equals, "`Destination` does not match AcsURL (expected \"https://15661444.ngrok.io/saml2/acs\", actual \"\")")
+}
+
 func (test *ServiceProviderTest) TestInvalidResponses(c *C) {
 	s := ServiceProvider{
 		Key:         test.Key,
@@ -661,12 +743,6 @@ func (test *ServiceProviderTest) TestInvalidResponses(c *C) {
 	req.PostForm.Set("SAMLResponse", base64.StdEncoding.EncodeToString([]byte("<hello>World!</hello>")))
 	_, err = s.ParseResponse(&req, []string{"id-9e61753d64e928af5a7a341a97f420c9"})
 	c.Assert(err.(*InvalidResponseError).PrivateErr, ErrorMatches, "cannot unmarshal response: expected element type <Response> but have <hello>")
-
-	s.AcsURL = mustParseURL("https://wrong/saml2/acs")
-	req.PostForm.Set("SAMLResponse", base64.StdEncoding.EncodeToString([]byte(test.SamlResponse)))
-	_, err = s.ParseResponse(&req, []string{"id-9e61753d64e928af5a7a341a97f420c9"})
-	c.Assert(err.(*InvalidResponseError).PrivateErr.Error(), Equals, "`Destination` does not match AcsURL (expected \"https://wrong/saml2/acs\")")
-	s.AcsURL = mustParseURL("https://15661444.ngrok.io/saml2/acs")
 
 	req.PostForm.Set("SAMLResponse", base64.StdEncoding.EncodeToString([]byte(test.SamlResponse)))
 	_, err = s.ParseResponse(&req, []string{"wrongRequestID"})

--- a/service_provider_test.go
+++ b/service_provider_test.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/beevik/etree"
 	. "gopkg.in/check.v1"
-	"strings"
 )
 
 // Hook up gocheck into the "go test" runner.


### PR DESCRIPTION
This is a slight cleanup of https://github.com/crewjam/saml/pull/113, which seems to be abandoned, but I encountered the same issue.

As I understand the SAML docs, when sending a `Response` via HTTP POST for the web SSO profile (what is implemented by this library), assertions should be protected by a signature -- _either_ by signing the whole response, or by signing individual assertions. ([SAML Profiles](https://www.oasis-open.org/committees/download.php/56782/sstc-saml-profiles-errata-2.0-wd-07.pdf) 4.1.4.5)

Meanwhile, the `Destination` attribute must be included only if the whole response is signed. ([SAML Bindings](https://www.oasis-open.org/committees/download.php/56779/sstc-saml-bindings-errata-2.0-wd-06.pdf) 3.5.5.2)

So the upshot is that this PR changes the Destination validation to only occur if either a) the Destination attribute is present and non-empty or b) the response is signed.