### PR TITLE
update value of UnspecifiedNameIDFormat and EmailAddressNameIDFormat

### DIFF
--- a/service_provider.go
+++ b/service_provider.go
@@ -34,9 +34,9 @@ func (n NameIDFormat) Element() *etree.Element {
 
 // Name ID formats
 const (
-	UnspecifiedNameIDFormat  NameIDFormat = "urn:oasis:names:tc:SAML:2.0:nameid-format:unspecified"
+	UnspecifiedNameIDFormat  NameIDFormat = "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified"
 	TransientNameIDFormat    NameIDFormat = "urn:oasis:names:tc:SAML:2.0:nameid-format:transient"
-	EmailAddressNameIDFormat NameIDFormat = "urn:oasis:names:tc:SAML:2.0:nameid-format:emailAddress"
+	EmailAddressNameIDFormat NameIDFormat = "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress"
 	PersistentNameIDFormat   NameIDFormat = "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent"
 )
 


### PR DESCRIPTION
As per [SAML specification document](http://docs.oasis-open.org/security/saml/v2.0/saml-core-2.0-os.pdf), both uri for unspecified and email address must use `urn:oasis:names:tc:SAML:1.1:*` rather than `urn:oasis:names:tc:SAML:2.0*`.

I just tested on my environment with SAML 2.0 as SP and SAML 1.1 as IdP, I got error below unless I changed the `2.0` into `1.1`.

> <samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:InvalidNameIDPolicy"/></samlp:StatusCode>
