### PR TITLE
AllowIDPInitiated=true allows both IDP-initiated and normal

### DIFF
--- a/samlsp/middleware.go
+++ b/samlsp/middleware.go
@@ -76,11 +76,11 @@ func (m *Middleware) serveACS(w http.ResponseWriter, r *http.Request) {
 	possibleRequestIDs := []string{}
 	if m.ServiceProvider.AllowIDPInitiated {
 		possibleRequestIDs = append(possibleRequestIDs, "")
-	} else {
-		trackedRequests := m.RequestTracker.GetTrackedRequests(r)
-		for _, tr := range trackedRequests {
-			possibleRequestIDs = append(possibleRequestIDs, tr.SAMLRequestID)
-		}
+	}
+
+	trackedRequests := m.RequestTracker.GetTrackedRequests(r)
+	for _, tr := range trackedRequests {
+		possibleRequestIDs = append(possibleRequestIDs, tr.SAMLRequestID)
 	}
 
 	assertion, err := m.ServiceProvider.ParseResponse(r, possibleRequestIDs)


### PR DESCRIPTION
Previously, if `AllowIDPInitiated` was enabled, normal logins were not allowed and always resulted in `WARNING: received invalid saml response: ... 'InResponseTo' does not match any of the possible request IDs (expected [])`.

This changes the logic to always fill in `possibleRequestIDs` from the RequestTracker, but then also add an empty allowed entry if `AllowIDPInitiated` is set.