### PR TITLE
fix(slo): fix SessionIndex attribute in LogoutRequest

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -54,7 +54,7 @@ type LogoutRequest struct {
 	NameID       *NameID
 	Signature    *etree.Element
 
-	SessionIndex string `xml:",attr"`
+	SessionIndex *SessionIndex `xml:"SessionIndex"`
 }
 
 // Element returns an etree.Element representing the object in XML form.
@@ -77,8 +77,8 @@ func (r *LogoutRequest) Element() *etree.Element {
 	if r.Signature != nil {
 		el.AddChild(r.Signature)
 	}
-	if r.SessionIndex != "" {
-		el.CreateAttr("SessionIndex", r.SessionIndex)
+	if r.SessionIndex != nil {
+		el.AddChild(r.SessionIndex.Element())
 	}
 	return el
 }
@@ -618,6 +618,23 @@ func (a *NameID) Element() *etree.Element {
 	}
 	if a.Value != "" {
 		el.SetText(a.Value)
+	}
+	return el
+}
+
+// SessionIndex represents the SAML element SessionIndex.
+//
+// See http://docs.oasis-open.org/security/saml/v2.0/saml-core-2.0-os.pdf §3.7.1
+type SessionIndex struct {
+	Value string `xml:",chardata"`
+}
+
+// Element returns an etree.Element representing the object in XML form.
+func (s *SessionIndex) Element() *etree.Element {
+	el := etree.NewElement("samlp:SessionIndex")
+	el.CreateAttr("xmlns:samlp", "urn:oasis:names:tc:SAML:2.0:protocol")
+	if s.Value != "" {
+		el.SetText(s.Value)
 	}
 	return el
 }


### PR DESCRIPTION
I am currently integrating SLO with multiple Identity Providers. The first issue I have encountered is with the `SessionIndex` on OpenAM.

Some IDP (like OpenAM) are more strictly following the standard than others (say Okta, Google). The SessionIndex is supposed to be mandatory.  `SessionIndex` is first received in SAML Assertion Response and must be sent again in the `LogoutRequest`.

See:
- [OpenAM-11968](https://bugster.forgerock.org/jira/browse/OPENAM-11968)
- [OpenAM-3021](https://bugster.forgerock.org/jira/browse/OPENAM-3021)

In the current code, the `SessionIndex` is passed as an attribute while it should be passed as an independent tag. For example [here](https://github.com/mehcode/python-saml/blob/master/tests/logout-request-simple.xml) and [here](https://gitlab.mpcdf.mpg.de/nomad-lab/passport-saml/blob/master/test/static/logout_request_with_session_index.xml).

I have been able to have my LogoutRequest accepted by OpenAM with the following code.