### PR TITLE
add HTTPOnly bool to CookieSessionProvider

### DIFF
--- a/samlsp/new.go
+++ b/samlsp/new.go
@@ -84,6 +84,7 @@ func DefaultSessionProvider(opts Options) CookieSessionProvider {
 		Name:   cookieName,
 		Domain: cookieDomain,
 		MaxAge: maxAge,
+		HttpOnly: true,
 		Secure: cookieSecure,
 		Codec:  DefaultSessionCodec(opts),
 	}

--- a/samlsp/new.go
+++ b/samlsp/new.go
@@ -81,12 +81,12 @@ func DefaultSessionProvider(opts Options) CookieSessionProvider {
 	}
 
 	return CookieSessionProvider{
-		Name:   cookieName,
-		Domain: cookieDomain,
-		MaxAge: maxAge,
-		HttpOnly: true,
-		Secure: cookieSecure,
-		Codec:  DefaultSessionCodec(opts),
+		Name:     cookieName,
+		Domain:   cookieDomain,
+		MaxAge:   maxAge,
+		HTTPOnly: true,
+		Secure:   cookieSecure,
+		Codec:    DefaultSessionCodec(opts),
 	}
 }
 

--- a/samlsp/session_cookie.go
+++ b/samlsp/session_cookie.go
@@ -17,6 +17,7 @@ var _ SessionProvider = CookieSessionProvider{}
 type CookieSessionProvider struct {
 	Name   string
 	Domain string
+	HttpOnly bool
 	Secure bool
 	MaxAge time.Duration
 	Codec  SessionCodec
@@ -46,7 +47,7 @@ func (c CookieSessionProvider) CreateSession(w http.ResponseWriter, r *http.Requ
 		Domain:   c.Domain,
 		Value:    value,
 		MaxAge:   int(c.MaxAge.Seconds()),
-		HttpOnly: true,
+		HttpOnly: c.HttpOnly,
 		Secure:   c.Secure || r.URL.Scheme == "https",
 		Path:     "/",
 	})

--- a/samlsp/session_cookie.go
+++ b/samlsp/session_cookie.go
@@ -15,12 +15,12 @@ var _ SessionProvider = CookieSessionProvider{}
 // CookieSessionProvider is an implementation of SessionProvider that stores
 // session tokens in an HTTP cookie.
 type CookieSessionProvider struct {
-	Name   string
-	Domain string
-	HttpOnly bool
-	Secure bool
-	MaxAge time.Duration
-	Codec  SessionCodec
+	Name     string
+	Domain   string
+	HTTPOnly bool
+	Secure   bool
+	MaxAge   time.Duration
+	Codec    SessionCodec
 }
 
 // CreateSession is called when we have received a valid SAML assertion and
@@ -47,7 +47,7 @@ func (c CookieSessionProvider) CreateSession(w http.ResponseWriter, r *http.Requ
 		Domain:   c.Domain,
 		Value:    value,
 		MaxAge:   int(c.MaxAge.Seconds()),
-		HttpOnly: c.HttpOnly,
+		HttpOnly: c.HTTPOnly,
 		Secure:   c.Secure || r.URL.Scheme == "https",
 		Path:     "/",
 	})


### PR DESCRIPTION
Allows disabling the `httpOnly` cookie flag for the `CookieSessionProvider`. Useful for scenarios where front-end client code in the browser needs access to the cookie.

Default remains true for uses of `DefaultSessionProvider`. 