### PR TITLE
fix(slo): handle nil signature document in LogoutResponse

### DIFF
--- a/service_provider.go
+++ b/service_provider.go
@@ -907,6 +907,12 @@ func (sp *ServiceProvider) ValidateLogoutResponseRedirect(queryParameterData str
 	}
 
 	responseEl := doc.Root()
+	if responseEl == nil {
+		// avoid a panic error as the Signature and SigAlg can be carried via query parameter and are not necessarily
+		// part of the SAMLResponse data.
+		// TODO: validate the signature here
+		return nil
+	}
 	if err = sp.validateSigned(responseEl); err != nil {
 		return err
 	}


### PR DESCRIPTION
The last LogoutResponse pull request introduced a bug.

The LogoutResponse validation assumed that the `Signature` and `SigAlg` keys would be carried via the XML document from the `SAMLResponse` key. However this is not necessarily the case as those keys can also be sent via query parameters. If they are not present, that will cause the `doc.Root()` to be nil and therefore panic.

I would like to propose to simply bypass the validation **for now** as it requires some more work and another contribution.