### PR TITLE
Expose private error messages

### DIFF
--- a/samlsp/middleware_test.go
+++ b/samlsp/middleware_test.go
@@ -575,7 +575,8 @@ func TestMiddlewareRejectsInvalidCookie(t *testing.T) {
 	test := NewMiddlewareTest()
 
 	test.Middleware.OnError = func(w http.ResponseWriter, r *http.Request, err error) {
-		assert.EqualError(t, err, "Authentication failed")
+		assert.Contains(t, err.Error(), "Authentication failed")
+		//assert.EqualError(t, err, "Authentication failed")
 		http.Error(w, "forbidden", http.StatusTeapot)
 	}
 

--- a/service_provider.go
+++ b/service_provider.go
@@ -416,7 +416,7 @@ type InvalidResponseError struct {
 }
 
 func (ivr *InvalidResponseError) Error() string {
-	return fmt.Sprintf("Authentication failed")
+	return fmt.Sprintf("Authentication failed, %s", ivr.PrivateErr)
 }
 
 // ErrBadStatus is returned when the assertion provided is valid but the


### PR DESCRIPTION
Currently, private error messages are not visible when importing this library.