### PR TITLE
Change to allow idp initiated authentication when a dummy SubjectConfirmation is sent

### DIFF
--- a/service_provider.go
+++ b/service_provider.go
@@ -635,10 +635,15 @@ func (sp *ServiceProvider) validateAssertion(assertion *Assertion, possibleReque
 	}
 	for _, subjectConfirmation := range assertion.Subject.SubjectConfirmations {
 		requestIDvalid := false
-		for _, possibleRequestID := range possibleRequestIDs {
-			if subjectConfirmation.SubjectConfirmationData.InResponseTo == possibleRequestID {
-				requestIDvalid = true
-				break
+
+		if sp.AllowIDPInitiated {
+			requestIDvalid = true
+		} else {
+			for _, possibleRequestID := range possibleRequestIDs {
+				if subjectConfirmation.SubjectConfirmationData.InResponseTo == possibleRequestID {
+					requestIDvalid = true
+					break
+				}
 			}
 		}
 		if !requestIDvalid {


### PR DESCRIPTION
I'm using an IDP that sends a SubjectConfirmation assertion with the InResponseTo set to `__dummy__` with the authentication is IDP initiated. Given that the `AllowIDPInitiated` is checked on line 522 to determine whether requestIds should be considered, I think it makes sense to add it here too