### PR TITLE
SessionNotOnOrAfter is serialized to XML if set

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -892,7 +892,7 @@ func (a *ProxyRestriction) Element() *etree.Element {
 type AuthnStatement struct {
 	AuthnInstant        time.Time  `xml:",attr"`
 	SessionIndex        string     `xml:",attr"`
-	SessionNotOnOrAfter *time.Time `xml:",attr"`
+	SessionNotOnOrAfter *time.Time `xml:",attr,omitempty"`
 	SubjectLocality     *SubjectLocality
 	AuthnContext        AuthnContext
 }
@@ -903,6 +903,9 @@ func (a *AuthnStatement) Element() *etree.Element {
 	el.CreateAttr("AuthnInstant", a.AuthnInstant.Format(timeFormat))
 	if a.SessionIndex != "" {
 		el.CreateAttr("SessionIndex", a.SessionIndex)
+	}
+	if a.SessionNotOnOrAfter != nil {
+		el.CreateAttr("SessionNotOnOrAfter", a.SessionNotOnOrAfter.Format(timeFormat))
 	}
 	if a.SubjectLocality != nil {
 		el.AddChild(a.SubjectLocality.Element())
@@ -915,11 +918,13 @@ func (a *AuthnStatement) Element() *etree.Element {
 func (a *AuthnStatement) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	type Alias AuthnStatement
 	aux := &struct {
-		AuthnInstant RelaxedTime `xml:",attr"`
+		AuthnInstant        RelaxedTime  `xml:",attr"`
+		SessionNotOnOrAfter *RelaxedTime `xml:",attr,omitempty"`
 		*Alias
 	}{
-		AuthnInstant: RelaxedTime(a.AuthnInstant),
-		Alias:        (*Alias)(a),
+		AuthnInstant:        RelaxedTime(a.AuthnInstant),
+		SessionNotOnOrAfter: (*RelaxedTime)(a.SessionNotOnOrAfter),
+		Alias:               (*Alias)(a),
 	}
 	return e.EncodeElement(aux, start)
 }
@@ -928,7 +933,8 @@ func (a *AuthnStatement) MarshalXML(e *xml.Encoder, start xml.StartElement) erro
 func (a *AuthnStatement) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 	type Alias AuthnStatement
 	aux := &struct {
-		AuthnInstant RelaxedTime `xml:",attr"`
+		AuthnInstant        RelaxedTime  `xml:",attr"`
+		SessionNotOnOrAfter *RelaxedTime `xml:",attr,omitempty"`
 		*Alias
 	}{
 		Alias: (*Alias)(a),
@@ -937,6 +943,7 @@ func (a *AuthnStatement) UnmarshalXML(d *xml.Decoder, start xml.StartElement) er
 		return err
 	}
 	a.AuthnInstant = time.Time(aux.AuthnInstant)
+	a.SessionNotOnOrAfter = (*time.Time)(aux.SessionNotOnOrAfter)
 	return nil
 }
 

--- a/schema_test.go
+++ b/schema_test.go
@@ -3,6 +3,7 @@ package saml
 import (
 	"encoding/xml"
 	"testing"
+	"time"
 
 	"github.com/beevik/etree"
 	"github.com/stretchr/testify/assert"
@@ -44,5 +45,34 @@ func TestNameIDFormat(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t,
 		"<samlp:NameIDPolicy/>",
+		string(x))
+}
+
+func TestAuthnStatementXMLRoundTrip(t *testing.T) {
+	authnInstant := time.Date(2020, 7, 21, 12, 30, 45, 0, time.UTC)
+	sessionNotOnOrAfter := time.Date(2020, 7, 22, 15, 0, 0, 0, time.UTC)
+	expected := AuthnStatement{
+		AuthnInstant:        authnInstant,
+		SessionIndex:        "index",
+		SessionNotOnOrAfter: &sessionNotOnOrAfter,
+	}
+
+	doc := etree.NewDocument()
+	doc.SetRoot(expected.Element())
+	x, err := doc.WriteToBytes()
+	assert.NoError(t, err)
+	assert.Equal(t,
+		`<saml:AuthnStatement AuthnInstant="2020-07-21T12:30:45Z" SessionIndex="index" SessionNotOnOrAfter="2020-07-22T15:00:00Z"><saml:AuthnContext/></saml:AuthnStatement>`,
+		string(x))
+
+	var actual AuthnStatement
+	err = xml.Unmarshal(x, &actual)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, actual)
+
+	x, err = xml.Marshal(expected)
+	assert.NoError(t, err)
+	assert.Equal(t,
+		`<AuthnStatement AuthnInstant="2020-07-21T12:30:45Z" SessionIndex="index" SessionNotOnOrAfter="2020-07-22T15:00:00Z"><AuthnContext></AuthnContext></AuthnStatement>`,
 		string(x))
 }


### PR DESCRIPTION
It is currently possible to set SessionNotOnOrAfter directly on the Go structure, but it is not serialized to or deserialized from XML.