### PR TITLE
Spread the use of option SameSite to tracking cookies

### DIFF
--- a/samlsp/new.go
+++ b/samlsp/new.go
@@ -115,6 +115,7 @@ func DefaultRequestTracker(opts Options, serviceProvider *saml.ServiceProvider) 
 		NamePrefix:      "saml_",
 		Codec:           DefaultTrackedRequestCodec(opts),
 		MaxAge:          saml.MaxIssueDelay,
+		SameSite:        opts.CookieSameSite,
 	}
 }
 

--- a/samlsp/request_tracker_cookie.go
+++ b/samlsp/request_tracker_cookie.go
@@ -19,6 +19,7 @@ type CookieRequestTracker struct {
 	NamePrefix      string
 	Codec           TrackedRequestCodec
 	MaxAge          time.Duration
+	SameSite        http.SameSite
 }
 
 // TrackRequest starts tracking the SAML request with the given ID. It returns an
@@ -39,6 +40,7 @@ func (t CookieRequestTracker) TrackRequest(w http.ResponseWriter, r *http.Reques
 		Value:    signedTrackedRequest,
 		MaxAge:   int(t.MaxAge.Seconds()),
 		HttpOnly: true,
+		SameSite: t.SameSite,
 		Secure:   t.ServiceProvider.AcsURL.Scheme == "https",
 		Path:     t.ServiceProvider.AcsURL.Path,
 	})


### PR DESCRIPTION
This PR spreads the use of option [SameSite](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#SameSite_cookies) to cookies that are used to track pending requests. If there is no `SameSite` cookie attribute a browser blocks it and application can't recognize when a user passed authentication.