### PR TITLE
Handle IDP-initiated assertions when validating request IDs

### DIFF
--- a/service_provider.go
+++ b/service_provider.go
@@ -700,10 +700,14 @@ func (sp *ServiceProvider) validateAssertion(assertion *Assertion, possibleReque
 	}
 	for _, subjectConfirmation := range assertion.Subject.SubjectConfirmations {
 		requestIDvalid := false
-		for _, possibleRequestID := range possibleRequestIDs {
-			if subjectConfirmation.SubjectConfirmationData.InResponseTo == possibleRequestID {
-				requestIDvalid = true
-				break
+		if sp.AllowIDPInitiated {
+			requestIDvalid = true
+		} else {
+			for _, possibleRequestID := range possibleRequestIDs {
+				if subjectConfirmation.SubjectConfirmationData.InResponseTo == possibleRequestID {
+					requestIDvalid = true
+					break
+				}
 			}
 		}
 		if !requestIDvalid {


### PR DESCRIPTION
As documented in #151 and #268, IDP-initiated assertions will not
match any of the possible request IDs. This implements greenpau's
suggestion (approved by crewjam) from #268.