### PR TITLE
fix: logout response element Response -> LogoutResponse

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -1084,7 +1084,7 @@ type LogoutResponse struct {
 
 // Element returns an etree.Element representing the object in XML form.
 func (r *LogoutResponse) Element() *etree.Element {
-	el := etree.NewElement("samlp:Response")
+	el := etree.NewElement("samlp:LogoutResponse")
 	el.CreateAttr("xmlns:saml", "urn:oasis:names:tc:SAML:2.0:assertion")
 	el.CreateAttr("xmlns:samlp", "urn:oasis:names:tc:SAML:2.0:protocol")
 


### PR DESCRIPTION
Without this fix, you can't round-trip a serialized `LogoutResponse` back through `ValidateLogoutResponseRequest`. It chokes on XML unmarshaling because it's expecting a root element of `LogoutResponse`, not `Response`. This was discovered when trying to using the built-in IdP for an internal test of an sp-initiated SLO flow.