### PR TITLE
fix ValidateLogoutResponseRedirect to avoid double read of flate reader

### DIFF
--- a/service_provider.go
+++ b/service_provider.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"html/template"
+	"io/ioutil"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -1036,10 +1037,13 @@ func (sp *ServiceProvider) ValidateLogoutResponseRedirect(queryParameterData str
 
 	gr := flate.NewReader(bytes.NewBuffer(rawResponseBuf))
 
-	decoder := xml.NewDecoder(gr)
+	buf, err := ioutil.ReadAll(gr)
+	if err != nil {
+		return err
+	}
 
 	var resp LogoutResponse
-
+	decoder := xml.NewDecoder(bytes.NewReader(buf))
 	err = decoder.Decode(&resp)
 	if err != nil {
 		return fmt.Errorf("unable to flate decode: %s", err)
@@ -1050,7 +1054,7 @@ func (sp *ServiceProvider) ValidateLogoutResponseRedirect(queryParameterData str
 	}
 
 	doc := etree.NewDocument()
-	if _, err := doc.ReadFrom(gr); err != nil {
+	if _, err := doc.ReadFrom(bytes.NewReader(buf)); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
The existing code in ValidateLogoutResponseRedirect fails because it tries to re-read the SAMLResponse from the flate reader `gr` even though earlier in the function that response body has already been entirely consumed by the call to `decoder.Decode`.

This patch reads the flate-decompressed SAMLResponse into a buffer so that it can be read twice, first for unmarshalling and then again for signature validation.

I recognize the use of ioutil.ReadAll may be objectionable, let me know if you'd like it changed to something like an io.TeeReader.

This error was uncovered while attempting to use the built-in IdP in the package to build a test workflow for an sp-initiated single logout flow.