### PR TITLE
identity_provider: extend session with CustomAttributes

### DIFF
--- a/identity_provider.go
+++ b/identity_provider.go
@@ -43,6 +43,9 @@ type Session struct {
 	UserSurname           string
 	UserGivenName         string
 	UserScopedAffiliation string
+
+	XUserID    string
+	XAccountID string
 }
 
 // SessionProvider is an interface used by IdentityProvider to determine the
@@ -638,6 +641,30 @@ func (DefaultAssertionMaker) MakeAssertion(req *IdpAuthnRequest, session *Sessio
 			Values: []AttributeValue{{
 				Type:  "xs:string",
 				Value: session.UserScopedAffiliation,
+			}},
+		})
+	}
+
+	if session.XUserID != "" {
+		attributes = append(attributes, Attribute{
+			FriendlyName: "xUserId",
+			Name:         "xUserId",
+			NameFormat:   "urn:oasis:names:tc:SAML:2.0:attrname-format:uri",
+			Values: []AttributeValue{{
+				Type:  "xs:string",
+				Value: session.XUserID,
+			}},
+		})
+	}
+
+	if session.XAccountID != "" {
+		attributes = append(attributes, Attribute{
+			FriendlyName: "xAccountId",
+			Name:         "xAccountId",
+			NameFormat:   "urn:oasis:names:tc:SAML:2.0:attrname-format:uri",
+			Values: []AttributeValue{{
+				Type:  "xs:string",
+				Value: session.XAccountID,
 			}},
 		})
 	}

--- a/identity_provider.go
+++ b/identity_provider.go
@@ -44,8 +44,7 @@ type Session struct {
 	UserGivenName         string
 	UserScopedAffiliation string
 
-	XUserID    string
-	XAccountID string
+	CustomAttributes []Attribute
 }
 
 // SessionProvider is an interface used by IdentityProvider to determine the
@@ -645,28 +644,8 @@ func (DefaultAssertionMaker) MakeAssertion(req *IdpAuthnRequest, session *Sessio
 		})
 	}
 
-	if session.XUserID != "" {
-		attributes = append(attributes, Attribute{
-			FriendlyName: "xUserId",
-			Name:         "xUserId",
-			NameFormat:   "urn:oasis:names:tc:SAML:2.0:attrname-format:uri",
-			Values: []AttributeValue{{
-				Type:  "xs:string",
-				Value: session.XUserID,
-			}},
-		})
-	}
-
-	if session.XAccountID != "" {
-		attributes = append(attributes, Attribute{
-			FriendlyName: "xAccountId",
-			Name:         "xAccountId",
-			NameFormat:   "urn:oasis:names:tc:SAML:2.0:attrname-format:uri",
-			Values: []AttributeValue{{
-				Type:  "xs:string",
-				Value: session.XAccountID,
-			}},
-		})
+	for _, ca := range session.CustomAttributes {
+		attributes = append(attributes, ca)
 	}
 
 	if len(session.Groups) != 0 {


### PR DESCRIPTION
Hi,
I'm using this saml package to implement  my idp server for huaweicloud sso.
The problem is that huaweicloud ask `xAccountId` `xUserId` and `bpId` for saml idp response.
[huaweicloud doc](https://bbs.huaweicloud.com/blogs/158219) (I can't find english version, sorry)

So, I would like propose this PR to support custom attributes for idp session info.

 Thanks for all your hard working~
