### PR TITLE
Service provider support for artifact binding responses

### DIFF
--- a/identity_provider_test.go
+++ b/identity_provider_test.go
@@ -308,7 +308,7 @@ func TestIDPCanHandlePostRequestWithExistingSession(t *testing.T) {
 
 	w := httptest.NewRecorder()
 
-	authRequest, err := test.SP.MakeAuthenticationRequest(test.SP.GetSSOBindingLocation(HTTPRedirectBinding), HTTPRedirectBinding)
+	authRequest, err := test.SP.MakeAuthenticationRequest(test.SP.GetSSOBindingLocation(HTTPRedirectBinding), HTTPRedirectBinding, HTTPPostBinding)
 	assert.Check(t, err)
 	authRequestBuf, err := xml.Marshal(authRequest)
 	assert.Check(t, err)

--- a/metadata.go
+++ b/metadata.go
@@ -13,6 +13,12 @@ const HTTPPostBinding = "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
 // HTTPRedirectBinding is the official URN for the HTTP-Redirect binding (transport)
 const HTTPRedirectBinding = "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"
 
+// HTTPArtifactBinding is the official URN for the HTTP-Artifact binding (transport)
+const HTTPArtifactBinding = "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Artifact"
+
+// SOAPBinding is the official URN for the SOAP binding (transport)
+const SOAPBinding = "urn:oasis:names:tc:SAML:2.0:bindings:SOAP"
+
 // EntitiesDescriptor represents the SAML object of the same name.
 //
 // See http://docs.oasis-open.org/security/saml/v2.0/saml-metadata-2.0-os.pdf §2.3.1
@@ -203,6 +209,7 @@ type IDPSSODescriptor struct {
 	WantAuthnRequestsSigned *bool `xml:",attr"`
 
 	SingleSignOnServices       []Endpoint  `xml:"SingleSignOnService"`
+	ArtifactResolutionServices []Endpoint  `xml:"ArtifactResolutionService"`
 	NameIDMappingServices      []Endpoint  `xml:"NameIDMappingService"`
 	AssertionIDRequestServices []Endpoint  `xml:"AssertionIDRequestService"`
 	AttributeProfiles          []string    `xml:"AttributeProfile"`

--- a/samlsp/middleware.go
+++ b/samlsp/middleware.go
@@ -42,6 +42,7 @@ type Middleware struct {
 	ServiceProvider saml.ServiceProvider
 	OnError         func(w http.ResponseWriter, r *http.Request, err error)
 	Binding         string // either saml.HTTPPostBinding or saml.HTTPRedirectBinding
+	ResponseBinding string // either saml.HTTPPostBinding or saml.HTTPArtifactBinding
 	RequestTracker  RequestTracker
 	Session         SessionProvider
 }
@@ -140,7 +141,7 @@ func (m *Middleware) HandleStartAuthFlow(w http.ResponseWriter, r *http.Request)
 		}
 	}
 
-	authReq, err := m.ServiceProvider.MakeAuthenticationRequest(bindingLocation, binding)
+	authReq, err := m.ServiceProvider.MakeAuthenticationRequest(bindingLocation, binding, m.ResponseBinding)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/samlsp/new.go
+++ b/samlsp/new.go
@@ -14,17 +14,18 @@ import (
 
 // Options represents the parameters for creating a new middleware
 type Options struct {
-	EntityID          string
-	URL               url.URL
-	Key               *rsa.PrivateKey
-	Certificate       *x509.Certificate
-	Intermediates     []*x509.Certificate
-	AllowIDPInitiated bool
-	IDPMetadata       *saml.EntityDescriptor
-	SignRequest       bool
-	ForceAuthn        bool // TODO(ross): this should be *bool
-	CookieSameSite    http.SameSite
-	RelayStateFunc    func(w http.ResponseWriter, r *http.Request) string
+	EntityID            string
+	URL                 url.URL
+	Key                 *rsa.PrivateKey
+	Certificate         *x509.Certificate
+	Intermediates       []*x509.Certificate
+	AllowIDPInitiated   bool
+	IDPMetadata         *saml.EntityDescriptor
+	SignRequest         bool
+	UseArtifactResponse bool
+	ForceAuthn          bool // TODO(ross): this should be *bool
+	CookieSameSite      http.SameSite
+	RelayStateFunc      func(w http.ResponseWriter, r *http.Request) string
 }
 
 // DefaultSessionCodec returns the default SessionCodec for the provided options,
@@ -119,10 +120,14 @@ func New(opts Options) (*Middleware, error) {
 	m := &Middleware{
 		ServiceProvider: DefaultServiceProvider(opts),
 		Binding:         "",
+		ResponseBinding: saml.HTTPPostBinding,
 		OnError:         DefaultOnError,
 		Session:         DefaultSessionProvider(opts),
 	}
 	m.RequestTracker = DefaultRequestTracker(opts, &m.ServiceProvider)
+	if opts.UseArtifactResponse {
+		m.ResponseBinding = saml.HTTPArtifactBinding
+	}
 
 	return m, nil
 }

--- a/schema.go
+++ b/schema.go
@@ -296,6 +296,160 @@ func (a *NameIDPolicy) Element() *etree.Element {
 	return el
 }
 
+// ArtifactRequest represents the SAML object of the same name.
+type ArtifactResolve struct {
+	XMLName      xml.Name  `xml:"urn:oasis:names:tc:SAML:2.0:protocol ArtifactResponse"`
+	ID           string    `xml:",attr"`
+	Version      string    `xml:",attr"`
+	IssueInstant time.Time `xml:",attr"`
+	Issuer       *Issuer   `xml:"urn:oasis:names:tc:SAML:2.0:assertion Issuer"`
+	Signature    *etree.Element
+	Artifact     string `xml:"urn:oasis:names:tc:SAML:2.0:protocol Artifact"`
+}
+
+func (r *ArtifactResolve) Element() *etree.Element {
+	el := etree.NewElement("samlp:ArtifactResolve")
+	el.CreateAttr("xmlns:saml", "urn:oasis:names:tc:SAML:2.0:assertion")
+	el.CreateAttr("xmlns:samlp", "urn:oasis:names:tc:SAML:2.0:protocol")
+
+	// Note: This namespace is not used by any element or attribute name, but
+	// is required so that the AttributeValue type element can have a value like
+	// "xs:string". If we don't declare it here, then it will be stripped by the
+	// cannonicalizer. This could be avoided by providing a prefix list to the
+	// cannonicalizer, but prefix lists do not appear to be implemented correctly
+	// in some libraries, so the safest action is to always produce XML that is
+	// (a) in canonical form and (b) does not require prefix lists.
+	el.CreateAttr("xmlns:xs", "http://www.w3.org/2001/XMLSchema")
+
+	el.CreateAttr("ID", r.ID)
+	el.CreateAttr("Version", r.Version)
+	el.CreateAttr("IssueInstant", r.IssueInstant.Format(timeFormat))
+	if r.Issuer != nil {
+		el.AddChild(r.Issuer.Element())
+	}
+	artifact := etree.NewElement("samlp:Artifact")
+	artifact.SetText(r.Artifact)
+	el.AddChild(artifact)
+	if r.Signature != nil {
+		el.AddChild(r.Signature)
+	}
+	return el
+}
+
+// Return a SOAP Envelope contining the ArtifactResolve request
+func (r *ArtifactResolve) SoapRequest() *etree.Element {
+	envelope := etree.NewElement("soapenv:Envelope")
+	envelope.CreateAttr("xmlns:soapenv", "http://schemas.xmlsoap.org/soap/envelope/")
+	envelope.CreateAttr("xmlns:xsi", "http://www.w3.org/2001/XMLSchema-instance")
+	body := etree.NewElement("soapenv:Body")
+	envelope.AddChild(body)
+	body.AddChild(r.Element())
+	return envelope
+}
+
+// MarshalXML implements xml.Marshaler
+func (r *ArtifactResolve) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	type Alias ArtifactResolve
+	aux := &struct {
+		IssueInstant RelaxedTime `xml:",attr"`
+		*Alias
+	}{
+		IssueInstant: RelaxedTime(r.IssueInstant),
+		Alias:        (*Alias)(r),
+	}
+	return e.Encode(aux)
+}
+
+// UnmarshalXML implements xml.Unmarshaler
+func (r *ArtifactResolve) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	type Alias ArtifactResolve
+	aux := &struct {
+		IssueInstant RelaxedTime `xml:",attr"`
+		*Alias
+	}{
+		Alias: (*Alias)(r),
+	}
+	if err := d.DecodeElement(&aux, &start); err != nil {
+		return err
+	}
+	r.IssueInstant = time.Time(aux.IssueInstant)
+	return nil
+}
+
+// ArtifactResponse represents the SAML object of the same name.
+type ArtifactResponse struct {
+	XMLName      xml.Name  `xml:"urn:oasis:names:tc:SAML:2.0:protocol ArtifactResponse"`
+	ID           string    `xml:",attr"`
+	InResponseTo string    `xml:",attr"`
+	Version      string    `xml:",attr"`
+	IssueInstant time.Time `xml:",attr"`
+	Issuer       *Issuer   `xml:"urn:oasis:names:tc:SAML:2.0:assertion Issuer"`
+	Signature    *etree.Element
+	Status       Status   `xml:"urn:oasis:names:tc:SAML:2.0:protocol Status"`
+	Response     Response `xml:"urn:oasis:names:tc:SAML:2.0:protocol Response"`
+}
+
+// Element returns an etree.Element representing the object in XML form.
+func (r *ArtifactResponse) Element() *etree.Element {
+	el := etree.NewElement("samlp:ArtifactResponse")
+	el.CreateAttr("xmlns:saml", "urn:oasis:names:tc:SAML:2.0:assertion")
+	el.CreateAttr("xmlns:samlp", "urn:oasis:names:tc:SAML:2.0:protocol")
+
+	// Note: This namespace is not used by any element or attribute name, but
+	// is required so that the AttributeValue type element can have a value like
+	// "xs:string". If we don't declare it here, then it will be stripped by the
+	// cannonicalizer. This could be avoided by providing a prefix list to the
+	// cannonicalizer, but prefix lists do not appear to be implemented correctly
+	// in some libraries, so the safest action is to always produce XML that is
+	// (a) in canonical form and (b) does not require prefix lists.
+	el.CreateAttr("xmlns:xs", "http://www.w3.org/2001/XMLSchema")
+
+	el.CreateAttr("ID", r.ID)
+	if r.InResponseTo != "" {
+		el.CreateAttr("InResponseTo", r.InResponseTo)
+	}
+	el.CreateAttr("Version", r.Version)
+	el.CreateAttr("IssueInstant", r.IssueInstant.Format(timeFormat))
+	if r.Issuer != nil {
+		el.AddChild(r.Issuer.Element())
+	}
+	if r.Signature != nil {
+		el.AddChild(r.Signature)
+	}
+	el.AddChild(r.Status.Element())
+	el.AddChild(r.Response.Element())
+	return el
+}
+
+// MarshalXML implements xml.Marshaler
+func (r *ArtifactResponse) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	type Alias ArtifactResponse
+	aux := &struct {
+		IssueInstant RelaxedTime `xml:",attr"`
+		*Alias
+	}{
+		IssueInstant: RelaxedTime(r.IssueInstant),
+		Alias:        (*Alias)(r),
+	}
+	return e.Encode(aux)
+}
+
+// UnmarshalXML implements xml.Unmarshaler
+func (r *ArtifactResponse) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	type Alias ArtifactResponse
+	aux := &struct {
+		IssueInstant RelaxedTime `xml:",attr"`
+		*Alias
+	}{
+		Alias: (*Alias)(r),
+	}
+	if err := d.DecodeElement(&aux, &start); err != nil {
+		return err
+	}
+	r.IssueInstant = time.Time(aux.IssueInstant)
+	return nil
+}
+
 // Response represents the SAML object of the same name.
 //
 // See http://docs.oasis-open.org/security/saml/v2.0/saml-core-2.0-os.pdf

--- a/service_provider.go
+++ b/service_provider.go
@@ -196,6 +196,11 @@ func (sp *ServiceProvider) Metadata() *EntityDescriptor {
 						Location: sp.AcsURL.String(),
 						Index:    1,
 					},
+					{
+						Binding:  HTTPArtifactBinding,
+						Location: sp.AcsURL.String(),
+						Index:    2,
+					},
 				},
 			},
 		},
@@ -206,7 +211,7 @@ func (sp *ServiceProvider) Metadata() *EntityDescriptor {
 // the HTTP-Redirect binding. It returns a URL that we will redirect the user to
 // in order to start the auth process.
 func (sp *ServiceProvider) MakeRedirectAuthenticationRequest(relayState string) (*url.URL, error) {
-	req, err := sp.MakeAuthenticationRequest(sp.GetSSOBindingLocation(HTTPRedirectBinding), HTTPRedirectBinding)
+	req, err := sp.MakeAuthenticationRequest(sp.GetSSOBindingLocation(HTTPRedirectBinding), HTTPRedirectBinding, HTTPPostBinding)
 	if err != nil {
 		return nil, err
 	}
@@ -271,6 +276,19 @@ func (sp *ServiceProvider) GetSSOBindingLocation(binding string) string {
 	return ""
 }
 
+// GetArtifactBindingLocation returns URL for the IDP's Artifact binding of the
+// specified type
+func (sp *ServiceProvider) GetArtifactBindingLocation(binding string) string {
+	for _, idpSSODescriptor := range sp.IDPMetadata.IDPSSODescriptors {
+		for _, artifactResolutionService := range idpSSODescriptor.ArtifactResolutionServices {
+			if artifactResolutionService.Binding == binding {
+				return artifactResolutionService.Location
+			}
+		}
+	}
+	return ""
+}
+
 // GetSLOBindingLocation returns URL for the IDP's Single Log Out Service binding
 // of the specified type (HTTPRedirectBinding or HTTPPostBinding)
 func (sp *ServiceProvider) GetSLOBindingLocation(binding string) string {
@@ -327,16 +345,38 @@ func (sp *ServiceProvider) getIDPSigningCerts() ([]*x509.Certificate, error) {
 	return certs, nil
 }
 
+// MakeArtifactResolveRequest produces a new ArtifactResolve object to send to the idp's Artifact resolver
+func (sp *ServiceProvider) MakeArtifactResolveRequest(artifactID string) (*ArtifactResolve, error) {
+	req := ArtifactResolve{
+		ID:           fmt.Sprintf("id-%x", randomBytes(20)),
+		IssueInstant: TimeNow(),
+		Version:      "2.0",
+		Issuer: &Issuer{
+			Format: "urn:oasis:names:tc:SAML:2.0:nameid-format:entity",
+			Value:  firstSet(sp.EntityID, sp.MetadataURL.String()),
+		},
+		Artifact: artifactID,
+	}
+
+	if len(sp.SignatureMethod) > 0 {
+		if err := sp.SignArtifactResolve(&req); err != nil {
+			return nil, err
+		}
+	}
+
+	return &req, nil
+}
+
 // MakeAuthenticationRequest produces a new AuthnRequest object to send to the idpURL
 // that uses the specified binding (HTTPRedirectBinding or HTTPPostBinding)
-func (sp *ServiceProvider) MakeAuthenticationRequest(idpURL string, binding string) (*AuthnRequest, error) {
+func (sp *ServiceProvider) MakeAuthenticationRequest(idpURL string, binding string, resultBinding string) (*AuthnRequest, error) {
 
 	allowCreate := true
 	nameIDFormat := sp.nameIDFormat()
 	req := AuthnRequest{
 		AssertionConsumerServiceURL: sp.AcsURL.String(),
 		Destination:                 idpURL,
-		ProtocolBinding:             HTTPPostBinding, // default binding for the response
+		ProtocolBinding:             resultBinding, // default binding for the response
 		ID:                          fmt.Sprintf("id-%x", randomBytes(20)),
 		IssueInstant:                TimeNow(),
 		Version:                     "2.0",
@@ -390,6 +430,24 @@ func GetSigningContext(sp *ServiceProvider) (*dsig.SigningContext, error) {
 	return signingContext, nil
 }
 
+// SignArtifactResolve adds the `Signature` element to the `ArtifactResolve`.
+func (sp *ServiceProvider) SignArtifactResolve(req *ArtifactResolve) error {
+	signingContext, err := GetSigningContext(sp)
+	if err != nil {
+		return err
+	}
+	assertionEl := req.Element()
+
+	signedRequestEl, err := signingContext.SignEnveloped(assertionEl)
+	if err != nil {
+		return err
+	}
+
+	sigEl := signedRequestEl.Child[len(signedRequestEl.Child)-1]
+	req.Signature = sigEl.(*etree.Element)
+	return nil
+}
+
 // SignAuthnRequest adds the `Signature` element to the `AuthnRequest`.
 func (sp *ServiceProvider) SignAuthnRequest(req *AuthnRequest) error {
 
@@ -413,7 +471,7 @@ func (sp *ServiceProvider) SignAuthnRequest(req *AuthnRequest) error {
 // the HTTP-POST binding. It returns HTML text representing an HTML form that
 // can be sent presented to a browser to initiate the login process.
 func (sp *ServiceProvider) MakePostAuthenticationRequest(relayState string) ([]byte, error) {
-	req, err := sp.MakeAuthenticationRequest(sp.GetSSOBindingLocation(HTTPPostBinding), HTTPPostBinding)
+	req, err := sp.MakeAuthenticationRequest(sp.GetSSOBindingLocation(HTTPPostBinding), HTTPPostBinding, HTTPPostBinding)
 	if err != nil {
 		return nil, err
 	}
@@ -505,8 +563,8 @@ func (e ErrBadStatus) Error() string {
 	return e.Status
 }
 
-func responseIsSigned(response *etree.Document) (bool, error) {
-	signatureElement, err := findChild(response.Root(), "http://www.w3.org/2000/09/xmldsig#", "Signature")
+func responseIsSigned(response *etree.Element) (bool, error) {
+	signatureElement, err := findChild(response, "http://www.w3.org/2000/09/xmldsig#", "Signature")
 	if err != nil {
 		return false, err
 	}
@@ -515,14 +573,8 @@ func responseIsSigned(response *etree.Document) (bool, error) {
 
 // validateDestination validates the Destination attribute.
 // If the response is signed, the Destination is required to be present.
-func (sp *ServiceProvider) validateDestination(response []byte, responseDom *Response) error {
-	responseXML := etree.NewDocument()
-	err := responseXML.ReadFromBytes(response)
-	if err != nil {
-		return err
-	}
-
-	signed, err := responseIsSigned(responseXML)
+func (sp *ServiceProvider) validateDestination(response *etree.Element, responseDom *Response) error {
+	signed, err := responseIsSigned(response)
 	if err != nil {
 		return err
 	}
@@ -538,31 +590,162 @@ func (sp *ServiceProvider) validateDestination(response []byte, responseDom *Res
 	return nil
 }
 
-// ParseResponse extracts the SAML IDP response received in req, validates
-// it, and returns the verified assertion.
+// ParseResponse extracts the SAML IDP response received in req, resolves
+// artifacts when neccessary, validates it, and returns the verified assertion.
 func (sp *ServiceProvider) ParseResponse(req *http.Request, possibleRequestIDs []string) (*Assertion, error) {
 	now := TimeNow()
+
+	var assertion *Assertion
+
 	retErr := &InvalidResponseError{
 		Now:      now,
 		Response: req.PostForm.Get("SAMLResponse"),
 	}
 
-	rawResponseBuf, err := base64.StdEncoding.DecodeString(req.PostForm.Get("SAMLResponse"))
-	if err != nil {
-		retErr.PrivateErr = fmt.Errorf("cannot parse base64: %s", err)
-		return nil, retErr
-	}
-	retErr.Response = string(rawResponseBuf)
-	assertion, err := sp.ParseXMLResponse(rawResponseBuf, possibleRequestIDs)
-	if err != nil {
-		return nil, err
+	if req.Form.Get("SAMLart") != "" {
+		retErr.Response = req.Form.Get("SAMLart")
+
+		req, err := sp.MakeArtifactResolveRequest(req.Form.Get("SAMLart"))
+		if err != nil {
+			retErr.PrivateErr = fmt.Errorf("Cannot generate artifact resolution request: %s", err)
+			return nil, retErr
+		}
+
+		doc := etree.NewDocument()
+		doc.SetRoot(req.SoapRequest())
+
+		var requestBuffer bytes.Buffer
+		doc.WriteTo(&requestBuffer)
+		response, err := http.Post(sp.GetArtifactBindingLocation(SOAPBinding), "text/xml", &requestBuffer)
+		if err != nil {
+			retErr.PrivateErr = fmt.Errorf("Error during artifact resolution: %s", err)
+			return nil, retErr
+		}
+		defer response.Body.Close()
+		if response.StatusCode != 200 {
+			retErr.PrivateErr = fmt.Errorf("Error during artifact resolution: HTTP status %d (%s)", response.StatusCode, response.Status)
+			return nil, retErr
+		}
+		rawResponseBuf, err := ioutil.ReadAll(response.Body)
+		if err != nil {
+			retErr.PrivateErr = fmt.Errorf("Error during artifact resolution: %s", err)
+			return nil, retErr
+		}
+		assertion, err = sp.ParseXMLArtifactResponse(rawResponseBuf, possibleRequestIDs, req.ID)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		rawResponseBuf, err := base64.StdEncoding.DecodeString(req.PostForm.Get("SAMLResponse"))
+		if err != nil {
+			retErr.PrivateErr = fmt.Errorf("cannot parse base64: %s", err)
+			return nil, retErr
+		}
+		retErr.Response = string(rawResponseBuf)
+		assertion, err = sp.ParseXMLResponse(rawResponseBuf, possibleRequestIDs)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return assertion, nil
 
 }
 
-// ParseXMLResponse validates the SAML IDP response and
+// ParseXMLArtifactResponse validates the SAML Artifact resolver response
+// and returns the verified assertion.
+//
+// This function handles verifying the digital signature, and verifying
+// that the specified conditions and properties are met.
+//
+// If the function fails it will return an InvalidResponseError whose
+// properties are useful in describing which part of the parsing process
+// failed. However, to discourage inadvertent disclosure the diagnostic
+// information, the Error() method returns a static string.
+func (sp *ServiceProvider) ParseXMLArtifactResponse(decodedResponseXML []byte, possibleRequestIDs []string, artifactRequestID string) (*Assertion, error) {
+	now := TimeNow()
+	//var err error
+	retErr := &InvalidResponseError{
+		Now:      now,
+		Response: string(decodedResponseXML),
+	}
+
+	// ensure that the response XML is well formed before we parse it
+	if err := xrv.Validate(bytes.NewReader(decodedResponseXML)); err != nil {
+		retErr.PrivateErr = fmt.Errorf("invalid xml: %s", err)
+		return nil, retErr
+	}
+
+	envelope := &struct {
+		XMLName xml.Name `xml:"http://schemas.xmlsoap.org/soap/envelope/ Envelope"`
+		Body    struct {
+			ArtifactResponse ArtifactResponse
+		} `xml:"http://schemas.xmlsoap.org/soap/envelope/ Body"`
+	}{}
+	if err := xml.Unmarshal(decodedResponseXML, &envelope); err != nil {
+		retErr.PrivateErr = fmt.Errorf("cannot unmarshal response: %s", err)
+		return nil, retErr
+	}
+
+	resp := envelope.Body.ArtifactResponse
+
+	// Validate ArtifactResponse
+	if resp.InResponseTo != artifactRequestID {
+		retErr.PrivateErr = fmt.Errorf("`InResponseTo` does not match the artifact request ID (expected %v)", artifactRequestID)
+		return nil, retErr
+	}
+	if resp.IssueInstant.Add(MaxIssueDelay).Before(now) {
+		retErr.PrivateErr = fmt.Errorf("response IssueInstant expired at %s", resp.IssueInstant.Add(MaxIssueDelay))
+		return nil, retErr
+	}
+	if resp.Issuer != nil && resp.Issuer.Value != sp.IDPMetadata.EntityID {
+		retErr.PrivateErr = fmt.Errorf("response Issuer does not match the IDP metadata (expected %q)", sp.IDPMetadata.EntityID)
+		return nil, retErr
+	}
+	if resp.Status.StatusCode.Value != StatusSuccess {
+		retErr.PrivateErr = ErrBadStatus{Status: resp.Status.StatusCode.Value}
+		return nil, retErr
+	}
+
+	doc := etree.NewDocument()
+	if err := doc.ReadFromBytes(decodedResponseXML); err != nil {
+		retErr.PrivateErr = err
+		return nil, retErr
+	}
+
+	artifactEl := doc.FindElement("Envelope/Body/ArtifactResponse")
+	if artifactEl == nil {
+		retErr.PrivateErr = fmt.Errorf("missing ArtifactResponse")
+		return nil, retErr
+	}
+	responseEl := doc.FindElement("Envelope/Body/ArtifactResponse/Response")
+	if responseEl == nil {
+		retErr.PrivateErr = fmt.Errorf("missing inner Response")
+		return nil, retErr
+	}
+
+	haveSignature := false
+	var err error
+	if err = sp.validateArtifactSigned(artifactEl); err != nil && err.Error() != "either the Response or Assertion must be signed" {
+		retErr.PrivateErr = err
+		return nil, retErr
+	}
+	if err == nil {
+		haveSignature = true
+	}
+	assertion, err, updatedResponse := sp.validateXMLResponse(&resp.Response, responseEl, possibleRequestIDs, now, !haveSignature)
+	if err != nil {
+		retErr.PrivateErr = err
+		if updatedResponse != nil {
+			retErr.Response = *updatedResponse
+		}
+		return nil, retErr
+	}
+
+	return assertion, nil
+}
+
+// ParseXMLResponse parses and validates the SAML IDP response and
 // returns the verified assertion.
 //
 // This function handles decrypting the message, verifying the digital
@@ -594,9 +777,35 @@ func (sp *ServiceProvider) ParseXMLResponse(decodedResponseXML []byte, possibleR
 		return nil, retErr
 	}
 
-	if err := sp.validateDestination(decodedResponseXML, &resp); err != nil {
+	doc := etree.NewDocument()
+	if err := doc.ReadFromBytes(decodedResponseXML); err != nil {
 		retErr.PrivateErr = err
 		return nil, retErr
+	}
+
+	assertion, err, updatedResponse := sp.validateXMLResponse(&resp, doc.Root(), possibleRequestIDs, now, true)
+	if err != nil {
+		retErr.PrivateErr = err
+		if updatedResponse != nil {
+			retErr.Response = *updatedResponse
+		}
+		return nil, retErr
+	}
+
+	return assertion, nil
+}
+
+// validateXMLResponse validates the SAML IDP response and returns
+// the verified assertion.
+//
+// This function handles decrypting the message, verifying the digital
+// signature on the assertion, and verifying that the specified conditions
+// and properties are met.
+func (sp *ServiceProvider) validateXMLResponse(resp *Response, responseEl *etree.Element, possibleRequestIDs []string, now time.Time, needSig bool) (*Assertion, error, *string) {
+	var err error
+	var updatedResponse *string
+	if err := sp.validateDestination(responseEl, resp); err != nil {
+		return nil, err, updatedResponse
 	}
 
 	requestIDvalid := false
@@ -612,42 +821,28 @@ func (sp *ServiceProvider) ParseXMLResponse(decodedResponseXML []byte, possibleR
 	}
 
 	if !requestIDvalid {
-		retErr.PrivateErr = fmt.Errorf("`InResponseTo` does not match any of the possible request IDs (expected %v)", possibleRequestIDs)
-		return nil, retErr
+		return nil, fmt.Errorf("`InResponseTo` does not match any of the possible request IDs (expected %v)", possibleRequestIDs), updatedResponse
 	}
 
 	if resp.IssueInstant.Add(MaxIssueDelay).Before(now) {
-		retErr.PrivateErr = fmt.Errorf("response IssueInstant expired at %s", resp.IssueInstant.Add(MaxIssueDelay))
-		return nil, retErr
+		return nil, fmt.Errorf("response IssueInstant expired at %s", resp.IssueInstant.Add(MaxIssueDelay)), updatedResponse
 	}
 	if resp.Issuer != nil && resp.Issuer.Value != sp.IDPMetadata.EntityID {
-		retErr.PrivateErr = fmt.Errorf("response Issuer does not match the IDP metadata (expected %q)", sp.IDPMetadata.EntityID)
-		return nil, retErr
+		return nil, fmt.Errorf("response Issuer does not match the IDP metadata (expected %q)", sp.IDPMetadata.EntityID), updatedResponse
 	}
 	if resp.Status.StatusCode.Value != StatusSuccess {
-		retErr.PrivateErr = ErrBadStatus{Status: resp.Status.StatusCode.Value}
-		return nil, retErr
+		return nil, ErrBadStatus{Status: resp.Status.StatusCode.Value}, updatedResponse
 	}
 
 	var assertion *Assertion
 	if resp.EncryptedAssertion == nil {
-
-		doc := etree.NewDocument()
-		if err := doc.ReadFromBytes(decodedResponseXML); err != nil {
-			retErr.PrivateErr = err
-			return nil, retErr
-		}
-
 		// TODO(ross): verify that the namespace is urn:oasis:names:tc:SAML:2.0:protocol
-		responseEl := doc.Root()
 		if responseEl.Tag != "Response" {
-			retErr.PrivateErr = fmt.Errorf("expected to find a response object, not %s", doc.Root().Tag)
-			return nil, retErr
+			return nil, fmt.Errorf("expected to find a response object, not %s", responseEl.Tag), updatedResponse
 		}
 
-		if err = sp.validateSigned(responseEl); err != nil {
-			retErr.PrivateErr = err
-			return nil, retErr
+		if err = sp.validateSigned(responseEl); err != nil && !(!needSig && err.Error() == "either the Response or Assertion must be signed") {
+			return nil, err, updatedResponse
 		}
 
 		assertion = resp.Assertion
@@ -655,78 +850,64 @@ func (sp *ServiceProvider) ParseXMLResponse(decodedResponseXML []byte, possibleR
 
 	// decrypt the response
 	if resp.EncryptedAssertion != nil {
-		doc := etree.NewDocument()
-		if err := doc.ReadFromBytes(decodedResponseXML); err != nil {
-			retErr.PrivateErr = err
-			return nil, retErr
-		}
-
 		// encrypted assertions are part of the signature
 		// before decrypting the response verify that
-		responseSigned, err := responseIsSigned(doc)
+		responseSigned, err := responseIsSigned(responseEl)
 		if err != nil {
-			retErr.PrivateErr = err
-			return nil, retErr
+			return nil, err, updatedResponse
 		}
 		if responseSigned {
-			if err := sp.validateSigned(doc.Root()); err != nil {
-				retErr.PrivateErr = err
-				return nil, retErr
+			if err := sp.validateSigned(responseEl); err != nil {
+				return nil, err, updatedResponse
 			}
 		}
 
 		var key interface{} = sp.Key
-		keyEl := doc.FindElement("//EncryptedAssertion/EncryptedKey")
+		keyEl := responseEl.FindElement("//EncryptedAssertion/EncryptedKey")
 		if keyEl != nil {
 			key, err = xmlenc.Decrypt(sp.Key, keyEl)
 			if err != nil {
-				retErr.PrivateErr = fmt.Errorf("failed to decrypt key from response: %s", err)
-				return nil, retErr
+				return nil, fmt.Errorf("failed to decrypt key from response: %s", err), updatedResponse
 			}
 		}
 
-		el := doc.FindElement("//EncryptedAssertion/EncryptedData")
+		el := responseEl.FindElement("//EncryptedAssertion/EncryptedData")
 		plaintextAssertion, err := xmlenc.Decrypt(key, el)
 		if err != nil {
-			retErr.PrivateErr = fmt.Errorf("failed to decrypt response: %s", err)
-			return nil, retErr
+			return nil, fmt.Errorf("failed to decrypt response: %s", err), updatedResponse
 		}
-		retErr.Response = string(plaintextAssertion)
+		updatedResponse = new(string)
+		*updatedResponse = string(plaintextAssertion)
 
 		// TODO(ross): add test case for this
 		if err := xrv.Validate(bytes.NewReader(plaintextAssertion)); err != nil {
-			retErr.PrivateErr = fmt.Errorf("plaintext response contains invalid XML: %s", err)
-			return nil, retErr
+			return nil, fmt.Errorf("plaintext response contains invalid XML: %s", err), updatedResponse
 		}
 
-		doc = etree.NewDocument()
+		doc := etree.NewDocument()
 		if err := doc.ReadFromBytes(plaintextAssertion); err != nil {
-			retErr.PrivateErr = fmt.Errorf("cannot parse plaintext response %v", err)
-			return nil, retErr
+			return nil, fmt.Errorf("cannot parse plaintext response %v", err), updatedResponse
 		}
 
 		// the decrypted assertion may be signed too
 		// otherwise, a signed response is sufficient
-		if err := sp.validateSigned(doc.Root()); err != nil && !responseSigned {
-			retErr.PrivateErr = err
-			return nil, retErr
+		if err := sp.validateSigned(doc.Root()); err != nil && !((responseSigned || !needSig) && err.Error() == "either the Response or Assertion must be signed") {
+			return nil, err, updatedResponse
 		}
 
 		assertion = &Assertion{}
 		// Note: plaintextAssertion is known to be safe to parse because
 		// plaintextAssertion is unmodified from when xrv.Validate() was called above.
 		if err := xml.Unmarshal(plaintextAssertion, assertion); err != nil {
-			retErr.PrivateErr = err
-			return nil, retErr
+			return nil, err, updatedResponse
 		}
 	}
 
 	if err := sp.validateAssertion(assertion, possibleRequestIDs, now); err != nil {
-		retErr.PrivateErr = fmt.Errorf("assertion invalid: %s", err)
-		return nil, retErr
+		return nil, fmt.Errorf("assertion invalid: %s", err), updatedResponse
 	}
 
-	return assertion, nil
+	return assertion, nil, updatedResponse
 }
 
 // validateAssertion checks that the conditions specified in assertion match
@@ -824,6 +1005,42 @@ func findChild(parentEl *etree.Element, childNS string, childTag string) (*etree
 		return childEl, nil
 	}
 	return nil, nil
+}
+
+// validateArtifactSigned returns a nil error iff each of the signatures on the ArtifactResponse, Response
+// and Assertion elements are valid and there is at least one signature.
+func (sp *ServiceProvider) validateArtifactSigned(artifactEl *etree.Element) error {
+	haveSignature := false
+
+	sigEl, err := findChild(artifactEl, "http://www.w3.org/2000/09/xmldsig#", "Signature")
+	if err != nil {
+		return err
+	}
+	if sigEl != nil {
+		if err = sp.validateSignature(artifactEl); err != nil {
+			return fmt.Errorf("cannot validate signature on Response: %v", err)
+		}
+		haveSignature = true
+	}
+
+	responseEl, err := findChild(artifactEl, "urn:oasis:names:tc:SAML:2.0:protocol", "Response")
+	if err != nil {
+		return err
+	}
+	if responseEl != nil {
+		err = sp.validateSigned(responseEl)
+		if err != nil && err.Error() != "either the Response or Assertion must be signed" {
+			return err
+		}
+		if err == nil {
+			haveSignature = true // guaranteed by validateSigned
+		}
+	}
+
+	if !haveSignature {
+		return errors.New("either the ArtifactResponse, Response or Assertion must be signed")
+	}
+	return nil
 }
 
 // validateSigned returns a nil error iff each of the signatures on the Response and Assertion elements

--- a/service_provider_test.go
+++ b/service_provider_test.go
@@ -81,25 +81,25 @@ func TestSPCanSetAuthenticationNameIDFormat(t *testing.T) {
 	}
 
 	// defaults to "transient"
-	req, err := s.MakeAuthenticationRequest("", HTTPRedirectBinding)
+	req, err := s.MakeAuthenticationRequest("", HTTPRedirectBinding, HTTPPostBinding)
 	assert.Check(t, err)
 	assert.Check(t, is.Equal(string(TransientNameIDFormat), *req.NameIDPolicy.Format))
 
 	// explicitly set to "transient"
 	s.AuthnNameIDFormat = TransientNameIDFormat
-	req, err = s.MakeAuthenticationRequest("", HTTPRedirectBinding)
+	req, err = s.MakeAuthenticationRequest("", HTTPRedirectBinding, HTTPPostBinding)
 	assert.Check(t, err)
 	assert.Check(t, is.Equal(string(TransientNameIDFormat), *req.NameIDPolicy.Format))
 
 	// explicitly set to "unspecified"
 	s.AuthnNameIDFormat = UnspecifiedNameIDFormat
-	req, err = s.MakeAuthenticationRequest("", HTTPRedirectBinding)
+	req, err = s.MakeAuthenticationRequest("", HTTPRedirectBinding, HTTPPostBinding)
 	assert.Check(t, err)
 	assert.Check(t, is.Equal("", *req.NameIDPolicy.Format))
 
 	// explicitly set to "emailAddress"
 	s.AuthnNameIDFormat = EmailAddressNameIDFormat
-	req, err = s.MakeAuthenticationRequest("", HTTPRedirectBinding)
+	req, err = s.MakeAuthenticationRequest("", HTTPRedirectBinding, HTTPPostBinding)
 	assert.Check(t, err)
 	assert.Check(t, is.Equal(string(EmailAddressNameIDFormat), *req.NameIDPolicy.Format))
 }


### PR DESCRIPTION
This PR provides an implementation of service-provider support for artifact binding, which is required by some identity providers as it is perceived to provide better security.

Current limitations are
 - This only implements artifact binding for receiving the response from the service provider.
 - There is no IdP support in this pull request

Furthermore, there are some testcases that are currently failing as I am having some problems regenerating the golden data used during testing. Any help in fixing that would be deeply appreciated.