### PR TITLE
added option defaultRedirectURI

### DIFF
--- a/samlsp/middleware.go
+++ b/samlsp/middleware.go
@@ -91,7 +91,7 @@ func (m *Middleware) ServeACS(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	m.CreateSessionFromAssertion(w, r, assertion)
+	m.CreateSessionFromAssertion(w, r, assertion, m.ServiceProvider.DefaultRedirectURI)
 	return
 }
 
@@ -181,8 +181,7 @@ func (m *Middleware) HandleStartAuthFlow(w http.ResponseWriter, r *http.Request)
 }
 
 // CreateSessionFromAssertion is invoked by ServeHTTP when we have a new, valid SAML assertion.
-func (m *Middleware) CreateSessionFromAssertion(w http.ResponseWriter, r *http.Request, assertion *saml.Assertion) {
-	redirectURI := "/"
+func (m *Middleware) CreateSessionFromAssertion(w http.ResponseWriter, r *http.Request, assertion *saml.Assertion, redirectURI string) {
 	if trackedRequestIndex := r.Form.Get("RelayState"); trackedRequestIndex != "" {
 		trackedRequest, err := m.RequestTracker.GetTrackedRequest(r, trackedRequestIndex)
 		if err != nil {

--- a/samlsp/new.go
+++ b/samlsp/new.go
@@ -14,17 +14,18 @@ import (
 
 // Options represents the parameters for creating a new middleware
 type Options struct {
-	EntityID          string
-	URL               url.URL
-	Key               *rsa.PrivateKey
-	Certificate       *x509.Certificate
-	Intermediates     []*x509.Certificate
-	AllowIDPInitiated bool
-	IDPMetadata       *saml.EntityDescriptor
-	SignRequest       bool
-	ForceAuthn        bool // TODO(ross): this should be *bool
-	CookieSameSite    http.SameSite
-	RelayStateFunc    func(w http.ResponseWriter, r *http.Request) string
+	EntityID           string
+	URL                url.URL
+	Key                *rsa.PrivateKey
+	Certificate        *x509.Certificate
+	Intermediates      []*x509.Certificate
+	AllowIDPInitiated  bool
+	DefaultRedirectURI string
+	IDPMetadata        *saml.EntityDescriptor
+	SignRequest        bool
+	ForceAuthn         bool // TODO(ross): this should be *bool
+	CookieSameSite     http.SameSite
+	RelayStateFunc     func(w http.ResponseWriter, r *http.Request) string
 }
 
 // DefaultSessionCodec returns the default SessionCodec for the provided options,
@@ -94,18 +95,23 @@ func DefaultServiceProvider(opts Options) saml.ServiceProvider {
 		signatureMethod = ""
 	}
 
+	if opts.DefaultRedirectURI == "" {
+		opts.DefaultRedirectURI = "/"
+	}
+
 	return saml.ServiceProvider{
-		EntityID:          opts.EntityID,
-		Key:               opts.Key,
-		Certificate:       opts.Certificate,
-		Intermediates:     opts.Intermediates,
-		MetadataURL:       *metadataURL,
-		AcsURL:            *acsURL,
-		SloURL:            *sloURL,
-		IDPMetadata:       opts.IDPMetadata,
-		ForceAuthn:        forceAuthn,
-		SignatureMethod:   signatureMethod,
-		AllowIDPInitiated: opts.AllowIDPInitiated,
+		EntityID:           opts.EntityID,
+		Key:                opts.Key,
+		Certificate:        opts.Certificate,
+		Intermediates:      opts.Intermediates,
+		MetadataURL:        *metadataURL,
+		AcsURL:             *acsURL,
+		SloURL:             *sloURL,
+		IDPMetadata:        opts.IDPMetadata,
+		ForceAuthn:         forceAuthn,
+		SignatureMethod:    signatureMethod,
+		AllowIDPInitiated:  opts.AllowIDPInitiated,
+		DefaultRedirectURI: opts.DefaultRedirectURI,
 	}
 }
 

--- a/service_provider.go
+++ b/service_provider.go
@@ -102,6 +102,9 @@ type ServiceProvider struct {
 	// AllowIdpInitiated
 	AllowIDPInitiated bool
 
+	// DefaultRedirectURI where untracked requests (as of IDPInitiated) are redirected to
+	DefaultRedirectURI string
+
 	// SignatureVerifier, if non-nil, allows you to implement an alternative way
 	// to verify signatures.
 	SignatureVerifier SignatureVerifier


### PR DESCRIPTION
This pull request allows the customization of the redirectURI which defaults to "/" if there is no matching request in the RequestTracker (as of IDPInitiated sign on). If no custom redirectURI is provided, "/" is used for backwards compatibility.
I needed to specify an alternate URI than "/" for IDPInitiatedSignOn and this commit solves it.