### PR TITLE
Add XMLName field and xml tags to StatusMessage struct

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -515,7 +515,8 @@ const (
 //
 // See http://docs.oasis-open.org/security/saml/v2.0/saml-core-2.0-os.pdf §3.2.2.3
 type StatusMessage struct {
-	Value string
+	XMLName    xml.Name `xml:"urn:oasis:names:tc:SAML:2.0:protocol StatusMessage"`
+	Value      string   `xml:",chardata"`
 }
 
 // Element returns an etree.Element representing the object in XML form.


### PR DESCRIPTION
This PR adds the xml tags for the StatusMessage struct so the error message is deserialized correctly