### PR TITLE
Add the NotOnOrAfter optional attribute to <LogoutRequest>

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -51,6 +51,7 @@ type LogoutRequest struct {
 	ID           string    `xml:",attr"`
 	Version      string    `xml:",attr"`
 	IssueInstant time.Time `xml:",attr"`
+	NotOnOrAfter *time.Time `xml:",attr"`
 	Destination  string    `xml:",attr"`
 	Issuer       *Issuer   `xml:"urn:oasis:names:tc:SAML:2.0:assertion Issuer"`
 	NameID       *NameID
@@ -67,6 +68,9 @@ func (r *LogoutRequest) Element() *etree.Element {
 	el.CreateAttr("ID", r.ID)
 	el.CreateAttr("Version", r.Version)
 	el.CreateAttr("IssueInstant", r.IssueInstant.Format(timeFormat))
+	if r.NotOnOrAfter != nil {
+		el.CreateAttr("NotOnOrAfter", r.NotOnOrAfter.Format(timeFormat))
+	}
 	if r.Destination != "" {
 		el.CreateAttr("Destination", r.Destination)
 	}
@@ -90,9 +94,11 @@ func (r *LogoutRequest) MarshalXML(e *xml.Encoder, start xml.StartElement) error
 	type Alias LogoutRequest
 	aux := &struct {
 		IssueInstant RelaxedTime `xml:",attr"`
+		NotOnOrAfter *RelaxedTime `xml:",attr"`
 		*Alias
 	}{
 		IssueInstant: RelaxedTime(r.IssueInstant),
+		NotOnOrAfter: (*RelaxedTime)(r.NotOnOrAfter),
 		Alias:        (*Alias)(r),
 	}
 	return e.Encode(aux)
@@ -103,6 +109,7 @@ func (r *LogoutRequest) UnmarshalXML(d *xml.Decoder, start xml.StartElement) err
 	type Alias LogoutRequest
 	aux := &struct {
 		IssueInstant RelaxedTime `xml:",attr"`
+		NotOnOrAfter *RelaxedTime `xml:",attr"`
 		*Alias
 	}{
 		Alias: (*Alias)(r),
@@ -111,6 +118,7 @@ func (r *LogoutRequest) UnmarshalXML(d *xml.Decoder, start xml.StartElement) err
 		return err
 	}
 	r.IssueInstant = time.Time(aux.IssueInstant)
+	r.NotOnOrAfter = (*time.Time)(aux.NotOnOrAfter)
 	return nil
 }
 

--- a/schema_test.go
+++ b/schema_test.go
@@ -94,3 +94,78 @@ func TestAuthnStatementMarshalWithoutSessionNotOnOrAfter(t *testing.T) {
 	assert.Check(t, err)
 	assert.Check(t, is.DeepEqual(expected, actual))
 }
+
+func TestLogoutRequestXMLRoundTrip(t *testing.T) {
+	issueInstant := time.Date(2021, 10, 8, 12, 30, 0, 0, time.UTC)
+	notOnOrAfter := time.Date(2021, 10, 8, 12, 35, 0, 0, time.UTC)
+	expected := LogoutRequest{
+		ID:           "request-id",
+		Version:      "2.0",
+		IssueInstant: issueInstant,
+		NotOnOrAfter: &notOnOrAfter,
+		Issuer: &Issuer{
+			XMLName: xml.Name{
+				Space: "urn:oasis:names:tc:SAML:2.0:assertion",
+				Local: "Issuer",
+			},
+			Value: "uri:issuer",
+		},
+		NameID: &NameID{
+			Value: "name-id",
+		},
+		SessionIndex: &SessionIndex{
+			Value: "index",
+		},
+	}
+
+	doc := etree.NewDocument()
+	doc.SetRoot(expected.Element())
+	x, err := doc.WriteToBytes()
+	assert.Check(t, err)
+	assert.Check(t, is.Equal(`<samlp:LogoutRequest xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" ID="request-id" Version="2.0" IssueInstant="2021-10-08T12:30:00Z" NotOnOrAfter="2021-10-08T12:35:00Z"><saml:Issuer>uri:issuer</saml:Issuer><saml:NameID>name-id</saml:NameID><samlp:SessionIndex xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol">index</samlp:SessionIndex></samlp:LogoutRequest>`,
+		string(x)))
+
+	var actual LogoutRequest
+	err = xml.Unmarshal(x, &actual)
+	assert.Check(t, err)
+	assert.Check(t, is.DeepEqual(expected, actual))
+
+	x, err = xml.Marshal(expected)
+	assert.Check(t, err)
+	assert.Check(t, is.Equal(`<LogoutRequest xmlns="urn:oasis:names:tc:SAML:2.0:protocol" ID="request-id" Version="2.0" IssueInstant="2021-10-08T12:30:00Z" NotOnOrAfter="2021-10-08T12:35:00Z" Destination=""><Issuer xmlns="urn:oasis:names:tc:SAML:2.0:assertion" NameQualifier="" SPNameQualifier="" Format="" SPProvidedID="">uri:issuer</Issuer><NameID NameQualifier="" SPNameQualifier="" Format="" SPProvidedID="">name-id</NameID><SessionIndex>index</SessionIndex></LogoutRequest>`,
+		string(x)))
+}
+
+func TestLogoutRequestMarshalWithoutNotOnOrAfter(t *testing.T) {
+	issueInstant := time.Date(2021, 10, 8, 12, 30, 0, 0, time.UTC)
+	expected := LogoutRequest{
+		ID:           "request-id",
+		Version:      "2.0",
+		IssueInstant: issueInstant,
+		Issuer: &Issuer{
+			XMLName: xml.Name{
+				Space: "urn:oasis:names:tc:SAML:2.0:assertion",
+				Local: "Issuer",
+			},
+			Value: "uri:issuer",
+		},
+		NameID: &NameID{
+			Value: "name-id",
+		},
+		SessionIndex: &SessionIndex{
+			Value: "index",
+		},
+	}
+
+	doc := etree.NewDocument()
+	doc.SetRoot(expected.Element())
+	x, err := doc.WriteToBytes()
+	assert.Check(t, err)
+	assert.Check(t, is.Equal(`<samlp:LogoutRequest xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" ID="request-id" Version="2.0" IssueInstant="2021-10-08T12:30:00Z"><saml:Issuer>uri:issuer</saml:Issuer><saml:NameID>name-id</saml:NameID><samlp:SessionIndex xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol">index</samlp:SessionIndex></samlp:LogoutRequest>`,
+		string(x)))
+
+	var actual LogoutRequest
+	err = xml.Unmarshal(x, &actual)
+	assert.Check(t, err)
+	assert.Check(t, is.DeepEqual(expected, actual))
+}


### PR DESCRIPTION
This PR adds support for the optional `NotOnOrAfter` attribute for the `<LogoutRequest>` element. A service provider can receive a logout request from an identity provider during single logout and should validate that the logout request is not expired if the `NotOnOrAfter` attribute is included.