### PR TITLE
Allow to specify HTTPClient for SAML artifact resolution

### DIFF
--- a/samlsp/new.go
+++ b/samlsp/new.go
@@ -19,6 +19,7 @@ type Options struct {
 	Key                 *rsa.PrivateKey
 	Certificate         *x509.Certificate
 	Intermediates       []*x509.Certificate
+	HTTPClient          *http.Client
 	AllowIDPInitiated   bool
 	DefaultRedirectURI  string
 	IDPMetadata         *saml.EntityDescriptor
@@ -104,6 +105,7 @@ func DefaultServiceProvider(opts Options) saml.ServiceProvider {
 		EntityID:           opts.EntityID,
 		Key:                opts.Key,
 		Certificate:        opts.Certificate,
+ 		HTTPClient:         opts.HTTPClient,
 		Intermediates:      opts.Intermediates,
 		MetadataURL:        *metadataURL,
 		AcsURL:             *acsURL,

--- a/service_provider.go
+++ b/service_provider.go
@@ -72,6 +72,9 @@ type ServiceProvider struct {
 	Certificate   *x509.Certificate
 	Intermediates []*x509.Certificate
 
+	// HTTPClient to use during SAML artifact resolution
+	HTTPClient *http.Client
+
 	// MetadataURL is the full URL to the metadata endpoint on this host,
 	// i.e. https://example.com/saml/metadata
 	MetadataURL url.URL
@@ -629,7 +632,11 @@ func (sp *ServiceProvider) ParseResponse(req *http.Request, possibleRequestIDs [
 
 		var requestBuffer bytes.Buffer
 		doc.WriteTo(&requestBuffer)
-		response, err := http.Post(sp.GetArtifactBindingLocation(SOAPBinding), "text/xml", &requestBuffer)
+		client := sp.HTTPClient
+		if client == nil {
+			client = http.DefaultClient
+		}
+		response, err := client.Post(sp.GetArtifactBindingLocation(SOAPBinding), "text/xml", &requestBuffer)
 		if err != nil {
 			retErr.PrivateErr = fmt.Errorf("Error during artifact resolution: %s", err)
 			return nil, retErr


### PR DESCRIPTION
Inspired by: https://github.com/crewjam/saml/commit/39dbb6ff314f6cc1802a351d795645026e9cfaa4, instead of https://github.com/crewjam/saml/pull/414 I figured it would be better to make the `HTTPClient` configurable

