### PR TITLE
DPLY-1297 - Comment out adding roles to the jwt token.

### DIFF
--- a/samlsp/session_jwt.go
+++ b/samlsp/session_jwt.go
@@ -49,17 +49,23 @@ func (c JWTSessionCodec) New(assertion *saml.Assertion) (Session, error) {
 
 	claims.Attributes = map[string][]string{}
 
-	for _, attributeStatement := range assertion.AttributeStatements {
-		for _, attr := range attributeStatement.Attributes {
-			claimName := attr.FriendlyName
-			if claimName == "" {
-				claimName = attr.Name
-			}
-			for _, value := range attr.Values {
-				claims.Attributes[claimName] = append(claims.Attributes[claimName], value.Value)
-			}
-		}
-	}
+	/**
+	This block is commented out because it is responsible for adding all the attributes to JWT
+	Token. With our current Okta setup, users in Engineering Productivity have too many Spinnaker
+	roles and it is causing the JWT to exceed 4096 Bytes which means that the browser can't set
+	the cookie and goes into an infinite redirect loop with okta.
+	*/
+	//for _, attributeStatement := range assertion.AttributeStatements {
+	//	for _, attr := range attributeStatement.Attributes {
+	//		claimName := attr.FriendlyName
+	//		if claimName == "" {
+	//			claimName = attr.Name
+	//		}
+	//		for _, value := range attr.Values {
+	//			claims.Attributes[claimName] = append(claims.Attributes[claimName], value.Value)
+	//		}
+	//	}
+	//}
 
 	// add SessionIndex to claims Attributes
 	for _, authnStatement := range assertion.AuthnStatements {


### PR DESCRIPTION
Per our discussion in stand up the other day. This code is the responsible bit for adding all the roles to the JWT token. Left a comment as to why and left the code commented out in the event that we sort out a solution and need the code.