### PR TITLE
Respect redirectURI

### DIFF
--- a/samlsp/middleware.go
+++ b/samlsp/middleware.go
@@ -183,7 +183,8 @@ func (m *Middleware) HandleStartAuthFlow(w http.ResponseWriter, r *http.Request)
 
 // CreateSessionFromAssertion is invoked by ServeHTTP when we have a new, valid SAML assertion.
 func (m *Middleware) CreateSessionFromAssertion(w http.ResponseWriter, r *http.Request, assertion *saml.Assertion, redirectURI string) {
-	if trackedRequestIndex := r.Form.Get("RelayState"); trackedRequestIndex != "" {
+	overridden := redirectURI != ""
+	if trackedRequestIndex := r.Form.Get("RelayState"); trackedRequestIndex != "" && !overridden {
 		trackedRequest, err := m.RequestTracker.GetTrackedRequest(r, trackedRequestIndex)
 		if err != nil {
 			m.OnError(w, r, err)


### PR DESCRIPTION
Ensures the redirectURI is respected even if RelayState was found in the acs parameters.