### PR TITLE
Support configuring binding for SP SLO endpoints

### DIFF
--- a/samlsp/new.go
+++ b/samlsp/new.go
@@ -27,6 +27,7 @@ type Options struct {
 	ForceAuthn          bool // TODO(ross): this should be *bool
 	CookieSameSite      http.SameSite
 	RelayStateFunc      func(w http.ResponseWriter, r *http.Request) string
+	LogoutBindings      []string
 }
 
 // DefaultSessionCodec returns the default SessionCodec for the provided options,
@@ -100,6 +101,10 @@ func DefaultServiceProvider(opts Options) saml.ServiceProvider {
 		opts.DefaultRedirectURI = "/"
 	}
 
+	if len(opts.LogoutBindings) == 0 {
+		opts.LogoutBindings = []string{saml.HTTPPostBinding}
+	}
+
 	return saml.ServiceProvider{
 		EntityID:           opts.EntityID,
 		Key:                opts.Key,
@@ -113,6 +118,7 @@ func DefaultServiceProvider(opts Options) saml.ServiceProvider {
 		SignatureMethod:    signatureMethod,
 		AllowIDPInitiated:  opts.AllowIDPInitiated,
 		DefaultRedirectURI: opts.DefaultRedirectURI,
+		LogoutBindings:     opts.LogoutBindings,
 	}
 }
 

--- a/service_provider.go
+++ b/service_provider.go
@@ -111,6 +111,10 @@ type ServiceProvider struct {
 
 	// SignatureMethod, if non-empty, authentication requests will be signed
 	SignatureMethod string
+
+	// LogoutBindings specify the bindings available for SLO endpoint. If empty,
+	// HTTP-POST binding is used.
+	LogoutBindings []string
 }
 
 // MaxIssueDelay is the longest allowed time between when a SAML assertion is
@@ -178,6 +182,15 @@ func (sp *ServiceProvider) Metadata() *EntityDescriptor {
 		}
 	}
 
+	var sloEndpoints []Endpoint
+	for _, binding := range sp.LogoutBindings {
+		sloEndpoints = append(sloEndpoints, Endpoint{
+			Binding:          binding,
+			Location:         sp.SloURL.String(),
+			ResponseLocation: sp.SloURL.String(),
+		})
+	}
+
 	return &EntityDescriptor{
 		EntityID:   firstSet(sp.EntityID, sp.MetadataURL.String()),
 		ValidUntil: validUntil,
@@ -190,13 +203,7 @@ func (sp *ServiceProvider) Metadata() *EntityDescriptor {
 						KeyDescriptors:             keyDescriptors,
 						ValidUntil:                 &validUntil,
 					},
-					SingleLogoutServices: []Endpoint{
-						{
-							Binding:          HTTPPostBinding,
-							Location:         sp.SloURL.String(),
-							ResponseLocation: sp.SloURL.String(),
-						},
-					},
+					SingleLogoutServices: sloEndpoints,
 				},
 				AuthnRequestsSigned:  &authnRequestsSigned,
 				WantAssertionsSigned: &wantAssertionsSigned,

--- a/service_provider_test.go
+++ b/service_provider_test.go
@@ -107,12 +107,13 @@ func TestSPCanSetAuthenticationNameIDFormat(t *testing.T) {
 func TestSPCanProduceMetadataWithEncryptionCert(t *testing.T) {
 	test := NewServiceProviderTest(t)
 	s := ServiceProvider{
-		Key:         test.Key,
-		Certificate: test.Certificate,
-		MetadataURL: mustParseURL("https://example.com/saml2/metadata"),
-		AcsURL:      mustParseURL("https://example.com/saml2/acs"),
-		SloURL:      mustParseURL("https://example.com/saml2/slo"),
-		IDPMetadata: &EntityDescriptor{},
+		Key:            test.Key,
+		Certificate:    test.Certificate,
+		MetadataURL:    mustParseURL("https://example.com/saml2/metadata"),
+		AcsURL:         mustParseURL("https://example.com/saml2/acs"),
+		SloURL:         mustParseURL("https://example.com/saml2/slo"),
+		IDPMetadata:    &EntityDescriptor{},
+		LogoutBindings: []string{HTTPPostBinding},
 	}
 	err := xml.Unmarshal(test.IDPMetadata, &s.IDPMetadata)
 	assert.Check(t, err)
@@ -131,6 +132,7 @@ func TestSPCanProduceMetadataWithBothCerts(t *testing.T) {
 		AcsURL:          mustParseURL("https://example.com/saml2/acs"),
 		SloURL:          mustParseURL("https://example.com/saml2/slo"),
 		IDPMetadata:     &EntityDescriptor{},
+		LogoutBindings:  []string{HTTPPostBinding},
 		SignatureMethod: "not-empty",
 	}
 	err := xml.Unmarshal(test.IDPMetadata, &s.IDPMetadata)
@@ -145,9 +147,10 @@ func TestSPCanProduceMetadataWithBothCerts(t *testing.T) {
 func TestCanProduceMetadataNoCerts(t *testing.T) {
 	test := NewServiceProviderTest(t)
 	s := ServiceProvider{
-		MetadataURL: mustParseURL("https://example.com/saml2/metadata"),
-		AcsURL:      mustParseURL("https://example.com/saml2/acs"),
-		IDPMetadata: &EntityDescriptor{},
+		MetadataURL:    mustParseURL("https://example.com/saml2/metadata"),
+		AcsURL:         mustParseURL("https://example.com/saml2/acs"),
+		IDPMetadata:    &EntityDescriptor{},
+		LogoutBindings: []string{HTTPPostBinding},
 	}
 	err := xml.Unmarshal(test.IDPMetadata, &s.IDPMetadata)
 	assert.Check(t, err)
@@ -160,10 +163,48 @@ func TestCanProduceMetadataNoCerts(t *testing.T) {
 func TestCanProduceMetadataEntityID(t *testing.T) {
 	test := NewServiceProviderTest(t)
 	s := ServiceProvider{
-		EntityID:    "spn:11111111-2222-3333-4444-555555555555",
+		EntityID:       "spn:11111111-2222-3333-4444-555555555555",
+		MetadataURL:    mustParseURL("https://example.com/saml2/metadata"),
+		AcsURL:         mustParseURL("https://example.com/saml2/acs"),
+		IDPMetadata:    &EntityDescriptor{},
+		LogoutBindings: []string{HTTPPostBinding},
+	}
+	err := xml.Unmarshal(test.IDPMetadata, &s.IDPMetadata)
+	assert.Check(t, err)
+
+	spMetadata, err := xml.MarshalIndent(s.Metadata(), "", "  ")
+	assert.Check(t, err)
+	golden.Assert(t, string(spMetadata), t.Name()+"_metadata")
+}
+
+func TestSPCanProduceMetadataWithNoLougoutBindings(t *testing.T) {
+	test := NewServiceProviderTest(t)
+	s := ServiceProvider{
+		Key:         test.Key,
+		Certificate: test.Certificate,
 		MetadataURL: mustParseURL("https://example.com/saml2/metadata"),
 		AcsURL:      mustParseURL("https://example.com/saml2/acs"),
+		SloURL:      mustParseURL("https://example.com/saml2/slo"),
 		IDPMetadata: &EntityDescriptor{},
+	}
+	err := xml.Unmarshal(test.IDPMetadata, &s.IDPMetadata)
+	assert.Check(t, err)
+
+	spMetadata, err := xml.MarshalIndent(s.Metadata(), "", "  ")
+	assert.Check(t, err)
+	golden.Assert(t, string(spMetadata), t.Name()+"_metadata")
+}
+
+func TestSPCanProduceMetadataWithBothLougoutBindings(t *testing.T) {
+	test := NewServiceProviderTest(t)
+	s := ServiceProvider{
+		Key:            test.Key,
+		Certificate:    test.Certificate,
+		MetadataURL:    mustParseURL("https://example.com/saml2/metadata"),
+		AcsURL:         mustParseURL("https://example.com/saml2/acs"),
+		SloURL:         mustParseURL("https://example.com/saml2/slo"),
+		IDPMetadata:    &EntityDescriptor{},
+		LogoutBindings: []string{HTTPPostBinding, HTTPRedirectBinding},
 	}
 	err := xml.Unmarshal(test.IDPMetadata, &s.IDPMetadata)
 	assert.Check(t, err)

--- a/testdata/TestSPCanProduceMetadataWithBothLougoutBindings_metadata
+++ b/testdata/TestSPCanProduceMetadataWithBothLougoutBindings_metadata
@@ -1,0 +1,19 @@
+<EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata" validUntil="2015-12-03T01:57:09Z" entityID="https://example.com/saml2/metadata">
+  <SPSSODescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata" validUntil="2015-12-03T01:57:09Z" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol" AuthnRequestsSigned="false" WantAssertionsSigned="true">
+    <KeyDescriptor use="encryption">
+      <KeyInfo xmlns="http://www.w3.org/2000/09/xmldsig#">
+        <X509Data xmlns="http://www.w3.org/2000/09/xmldsig#">
+          <X509Certificate xmlns="http://www.w3.org/2000/09/xmldsig#">MIIB7zCCAVgCCQDFzbKIp7b3MTANBgkqhkiG9w0BAQUFADA8MQswCQYDVQQGEwJVUzELMAkGA1UECAwCR0ExDDAKBgNVBAoMA2ZvbzESMBAGA1UEAwwJbG9jYWxob3N0MB4XDTEzMTAwMjAwMDg1MVoXDTE0MTAwMjAwMDg1MVowPDELMAkGA1UEBhMCVVMxCzAJBgNVBAgMAkdBMQwwCgYDVQQKDANmb28xEjAQBgNVBAMMCWxvY2FsaG9zdDCBnzANBgkqhkiG9w0BAQEFAAOBjQAwgYkCgYEA1PMHYmhZj308kWLhZVT4vOulqx/9ibm5B86fPWwUKKQ2i12MYtz07tzukPymisTDhQaqyJ8Kqb/6JjhmeMnEOdTvSPmHO8m1ZVveJU6NoKRn/mP/BD7FW52WhbrUXLSeHVSKfWkNk6S4hk9MV9TswTvyRIKvRsw0X/gfnqkroJcCAwEAATANBgkqhkiG9w0BAQUFAAOBgQCMMlIO+GNcGekevKgkakpMdAqJfs24maGb90DvTLbRZRD7Xvn1MnVBBS9hzlXiFLYOInXACMW5gcoRFfeTQLSouMM8o57h0uKjfTmuoWHLQLi6hnF+cvCsEFiJZ4AbF+DgmO6TarJ8O05t8zvnOwJlNCASPZRH/JmF8tX0hoHuAQ==</X509Certificate>
+        </X509Data>
+      </KeyInfo>
+      <EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#aes128-cbc"></EncryptionMethod>
+      <EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#aes192-cbc"></EncryptionMethod>
+      <EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#aes256-cbc"></EncryptionMethod>
+      <EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p"></EncryptionMethod>
+    </KeyDescriptor>
+    <SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://example.com/saml2/slo" ResponseLocation="https://example.com/saml2/slo"></SingleLogoutService>
+    <SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://example.com/saml2/slo" ResponseLocation="https://example.com/saml2/slo"></SingleLogoutService>
+    <AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://example.com/saml2/acs" index="1"></AssertionConsumerService>
+    <AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Artifact" Location="https://example.com/saml2/acs" index="2"></AssertionConsumerService>
+  </SPSSODescriptor>
+</EntityDescriptor>

--- a/testdata/TestSPCanProduceMetadataWithNoLougoutBindings_metadata
+++ b/testdata/TestSPCanProduceMetadataWithNoLougoutBindings_metadata
@@ -1,0 +1,17 @@
+<EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata" validUntil="2015-12-03T01:57:09Z" entityID="https://example.com/saml2/metadata">
+  <SPSSODescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata" validUntil="2015-12-03T01:57:09Z" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol" AuthnRequestsSigned="false" WantAssertionsSigned="true">
+    <KeyDescriptor use="encryption">
+      <KeyInfo xmlns="http://www.w3.org/2000/09/xmldsig#">
+        <X509Data xmlns="http://www.w3.org/2000/09/xmldsig#">
+          <X509Certificate xmlns="http://www.w3.org/2000/09/xmldsig#">MIIB7zCCAVgCCQDFzbKIp7b3MTANBgkqhkiG9w0BAQUFADA8MQswCQYDVQQGEwJVUzELMAkGA1UECAwCR0ExDDAKBgNVBAoMA2ZvbzESMBAGA1UEAwwJbG9jYWxob3N0MB4XDTEzMTAwMjAwMDg1MVoXDTE0MTAwMjAwMDg1MVowPDELMAkGA1UEBhMCVVMxCzAJBgNVBAgMAkdBMQwwCgYDVQQKDANmb28xEjAQBgNVBAMMCWxvY2FsaG9zdDCBnzANBgkqhkiG9w0BAQEFAAOBjQAwgYkCgYEA1PMHYmhZj308kWLhZVT4vOulqx/9ibm5B86fPWwUKKQ2i12MYtz07tzukPymisTDhQaqyJ8Kqb/6JjhmeMnEOdTvSPmHO8m1ZVveJU6NoKRn/mP/BD7FW52WhbrUXLSeHVSKfWkNk6S4hk9MV9TswTvyRIKvRsw0X/gfnqkroJcCAwEAATANBgkqhkiG9w0BAQUFAAOBgQCMMlIO+GNcGekevKgkakpMdAqJfs24maGb90DvTLbRZRD7Xvn1MnVBBS9hzlXiFLYOInXACMW5gcoRFfeTQLSouMM8o57h0uKjfTmuoWHLQLi6hnF+cvCsEFiJZ4AbF+DgmO6TarJ8O05t8zvnOwJlNCASPZRH/JmF8tX0hoHuAQ==</X509Certificate>
+        </X509Data>
+      </KeyInfo>
+      <EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#aes128-cbc"></EncryptionMethod>
+      <EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#aes192-cbc"></EncryptionMethod>
+      <EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#aes256-cbc"></EncryptionMethod>
+      <EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p"></EncryptionMethod>
+    </KeyDescriptor>
+    <AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://example.com/saml2/acs" index="1"></AssertionConsumerService>
+    <AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Artifact" Location="https://example.com/saml2/acs" index="2"></AssertionConsumerService>
+  </SPSSODescriptor>
+</EntityDescriptor>


### PR DESCRIPTION
The PR supports configuration of the bindings for the SLO endpoint.

The default remains unchanged and it is HTTP-POST.

It is possible to configure HTTP-Redirect binding as follows:

```go
samlSP, _ := samlsp.New(samlsp.Options{
	URL:            *rootURL,
	Key:            keyPair.PrivateKey.(*rsa.PrivateKey),
	Certificate:    keyPair.Leaf,
	IDPMetadata: idpMetadata,
	LogoutBindings: []string{saml.HTTPRedirectBinding},
})
```

or to configure both bindings as follows:

```go
samlSP, _ := samlsp.New(samlsp.Options{
	URL:            *rootURL,
	Key:            keyPair.PrivateKey.(*rsa.PrivateKey),
	Certificate:    keyPair.Leaf,
	IDPMetadata: idpMetadata,
	LogoutBindings: []string{saml.HTTPPostBinding, saml.HTTPRedirectBinding},
})
```

This addresses https://github.com/crewjam/saml/issues/357