### PR TITLE
Add NameIDFormat to metadata

### DIFF
--- a/samlsp/testdata/expected_middleware_metadata.xml
+++ b/samlsp/testdata/expected_middleware_metadata.xml
@@ -12,6 +12,7 @@
       <EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p"></EncryptionMethod>
     </KeyDescriptor>
     <SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://15661444.ngrok.io/saml2/slo" ResponseLocation="https://15661444.ngrok.io/saml2/slo"></SingleLogoutService>
+    <NameIDFormat></NameIDFormat>
     <AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://15661444.ngrok.io/saml2/acs" index="1"></AssertionConsumerService>
     <AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Artifact" Location="https://15661444.ngrok.io/saml2/acs" index="2"></AssertionConsumerService>
   </SPSSODescriptor>

--- a/schema.go
+++ b/schema.go
@@ -764,7 +764,7 @@ func (a *Assertion) Element() *etree.Element {
 	for _, attributeStatement := range a.AttributeStatements {
 		el.AddChild(attributeStatement.Element())
 	}
-	err := etreeutils.TransformExcC14n(el, canonicalizerPrefixList, false)
+	err := etreeutils.TransformExcC14n(el, canonicalizerPrefixList)
 	if err != nil {
 		panic(err)
 	}

--- a/service_provider.go
+++ b/service_provider.go
@@ -204,6 +204,7 @@ func (sp *ServiceProvider) Metadata() *EntityDescriptor {
 							ResponseLocation: sp.SloURL.String(),
 						},
 					},
+					NameIDFormats: []NameIDFormat{sp.AuthnNameIDFormat},
 				},
 				AuthnRequestsSigned:  &authnRequestsSigned,
 				WantAssertionsSigned: &wantAssertionsSigned,

--- a/service_provider_test.go
+++ b/service_provider_test.go
@@ -125,13 +125,14 @@ func TestSPCanProduceMetadataWithEncryptionCert(t *testing.T) {
 func TestSPCanProduceMetadataWithBothCerts(t *testing.T) {
 	test := NewServiceProviderTest(t)
 	s := ServiceProvider{
-		Key:             test.Key,
-		Certificate:     test.Certificate,
-		MetadataURL:     mustParseURL("https://example.com/saml2/metadata"),
-		AcsURL:          mustParseURL("https://example.com/saml2/acs"),
-		SloURL:          mustParseURL("https://example.com/saml2/slo"),
-		IDPMetadata:     &EntityDescriptor{},
-		SignatureMethod: "not-empty",
+		Key:               test.Key,
+		Certificate:       test.Certificate,
+		MetadataURL:       mustParseURL("https://example.com/saml2/metadata"),
+		AcsURL:            mustParseURL("https://example.com/saml2/acs"),
+		SloURL:            mustParseURL("https://example.com/saml2/slo"),
+		IDPMetadata:       &EntityDescriptor{},
+		AuthnNameIDFormat: TransientNameIDFormat,
+		SignatureMethod:   "not-empty",
 	}
 	err := xml.Unmarshal(test.IDPMetadata, &s.IDPMetadata)
 	assert.Check(t, err)
@@ -145,9 +146,10 @@ func TestSPCanProduceMetadataWithBothCerts(t *testing.T) {
 func TestCanProduceMetadataNoCerts(t *testing.T) {
 	test := NewServiceProviderTest(t)
 	s := ServiceProvider{
-		MetadataURL: mustParseURL("https://example.com/saml2/metadata"),
-		AcsURL:      mustParseURL("https://example.com/saml2/acs"),
-		IDPMetadata: &EntityDescriptor{},
+		MetadataURL:       mustParseURL("https://example.com/saml2/metadata"),
+		AcsURL:            mustParseURL("https://example.com/saml2/acs"),
+		IDPMetadata:       &EntityDescriptor{},
+		AuthnNameIDFormat: TransientNameIDFormat,
 	}
 	err := xml.Unmarshal(test.IDPMetadata, &s.IDPMetadata)
 	assert.Check(t, err)

--- a/testdata/TestCanProduceMetadataEntityID_metadata
+++ b/testdata/TestCanProduceMetadataEntityID_metadata
@@ -1,6 +1,7 @@
 <EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata" validUntil="2015-12-03T01:57:09Z" entityID="spn:11111111-2222-3333-4444-555555555555">
   <SPSSODescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata" validUntil="2015-12-03T01:57:09Z" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol" AuthnRequestsSigned="false" WantAssertionsSigned="true">
     <SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location=""></SingleLogoutService>
+    <NameIDFormat></NameIDFormat>
     <AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://example.com/saml2/acs" index="1"></AssertionConsumerService>
     <AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Artifact" Location="https://example.com/saml2/acs" index="2"></AssertionConsumerService>
   </SPSSODescriptor>

--- a/testdata/TestCanProduceMetadataNoCerts_metadata
+++ b/testdata/TestCanProduceMetadataNoCerts_metadata
@@ -1,6 +1,7 @@
 <EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata" validUntil="2015-12-03T01:57:09Z" entityID="https://example.com/saml2/metadata">
   <SPSSODescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata" validUntil="2015-12-03T01:57:09Z" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol" AuthnRequestsSigned="false" WantAssertionsSigned="true">
     <SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location=""></SingleLogoutService>
+    <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</NameIDFormat>
     <AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://example.com/saml2/acs" index="1"></AssertionConsumerService>
     <AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Artifact" Location="https://example.com/saml2/acs" index="2"></AssertionConsumerService>
   </SPSSODescriptor>

--- a/testdata/TestSPCanProduceMetadataWithBothCerts_metadata
+++ b/testdata/TestSPCanProduceMetadataWithBothCerts_metadata
@@ -19,6 +19,7 @@
       </KeyInfo>
     </KeyDescriptor>
     <SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://example.com/saml2/slo" ResponseLocation="https://example.com/saml2/slo"></SingleLogoutService>
+    <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</NameIDFormat>
     <AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://example.com/saml2/acs" index="1"></AssertionConsumerService>
     <AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Artifact" Location="https://example.com/saml2/acs" index="2"></AssertionConsumerService>
   </SPSSODescriptor>

--- a/testdata/TestSPCanProduceMetadataWithEncryptionCert_metadata
+++ b/testdata/TestSPCanProduceMetadataWithEncryptionCert_metadata
@@ -12,6 +12,7 @@
       <EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p"></EncryptionMethod>
     </KeyDescriptor>
     <SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://example.com/saml2/slo" ResponseLocation="https://example.com/saml2/slo"></SingleLogoutService>
+    <NameIDFormat></NameIDFormat>
     <AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://example.com/saml2/acs" index="1"></AssertionConsumerService>
     <AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Artifact" Location="https://example.com/saml2/acs" index="2"></AssertionConsumerService>
   </SPSSODescriptor>


### PR DESCRIPTION
Return name ID format configured in SP metadata for IDPs requiring this information

Todo:

- [ ] Fix tests