### PR TITLE
chore: update github.com/russellhaering/goxmldsig to v1.2.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/google/go-cmp v0.5.8
 	github.com/mattermost/xml-roundtrip-validator v0.1.0
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/russellhaering/goxmldsig v1.1.1
+	github.com/russellhaering/goxmldsig v1.2.0
 	golang.org/x/crypto v0.0.0-20220128200615-198e4374d7ed
 	gotest.tools v2.2.0+incompatible
 )

--- a/go.sum
+++ b/go.sum
@@ -33,6 +33,8 @@ github.com/rogpeppe/go-internal v1.8.0 h1:FCbCCtXNOY3UtUuHUYaghJg4y7Fd14rXifAYUA
 github.com/rogpeppe/go-internal v1.8.0/go.mod h1:WmiCO8CzOY8rg0OYDC4/i/2WRWAB6poM+XZ2dLUbcbE=
 github.com/russellhaering/goxmldsig v1.1.1 h1:vI0r2osGF1A9PLvsGdPUAGwEIrKa4Pj5sesSBsebIxM=
 github.com/russellhaering/goxmldsig v1.1.1/go.mod h1:gM4MDENBQf7M+V824SGfyIUVFWydB7n0KkEubVJl+Tw=
+github.com/russellhaering/goxmldsig v1.2.0 h1:Y6GTTc9Un5hCxSzVz4UIWQ/zuVwDvzJk80guqzwx6Vg=
+github.com/russellhaering/goxmldsig v1.2.0/go.mod h1:gM4MDENBQf7M+V824SGfyIUVFWydB7n0KkEubVJl+Tw=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=

--- a/schema.go
+++ b/schema.go
@@ -764,7 +764,7 @@ func (a *Assertion) Element() *etree.Element {
 	for _, attributeStatement := range a.AttributeStatements {
 		el.AddChild(attributeStatement.Element())
 	}
-	err := etreeutils.TransformExcC14n(el, canonicalizerPrefixList)
+	err := etreeutils.TransformExcC14n(el, canonicalizerPrefixList, false)
 	if err != nil {
 		panic(err)
 	}

--- a/service_provider_test.go
+++ b/service_provider_test.go
@@ -776,12 +776,14 @@ func TestSPRejectsInjectedComment(t *testing.T) {
 
 		req := http.Request{PostForm: url.Values{}}
 		req.PostForm.Set("SAMLResponse", string(SamlResponse))
-		_, err := s.ParseResponse(&req, []string{"id-fd419a5ab0472645427f8e07d87a3a5dd0b2e9a6"})
-		assert.Check(t, err != nil)
+		assertion, err := s.ParseResponse(&req, []string{"id-fd419a5ab0472645427f8e07d87a3a5dd0b2e9a6"})
 
-		realErr := err.(*InvalidResponseError).PrivateErr
-		assert.Check(t, is.Error(realErr,
-			"cannot validate signature on Response: Signature could not be verified"))
+		// Note: The latest version of github.com/russellhaering/goxmldsig now correctly reads and
+		// switches on the CanonicalizationMethod presented in the assertion. The test assertion
+		// currently has the CanonicalizationMethod set to "http://www.w3.org/2001/10/xml-exc-c14n#WithComments"
+		// meaning the above comment injection will now be correctly stripped
+		assert.Check(t, err)
+		assert.Check(t, is.Equal("ross@octolabs.io", assertion.Subject.NameID.Value))
 	}
 }
 


### PR DESCRIPTION
This change set slightly duplicates earlier submissions but with test fixes and updates: https://github.com/crewjam/saml/pull/437 and https://github.com/crewjam/saml/pull/446

I ran into this in another project that consumes both `github.com/crewjam/saml` and `github.com/russellhaering/goxmldsig` at the top-level. The call signature for `github.com/russellhaering/goxmldsig/etreeutils.TransformExcC14n(...)` changed slightly and now accepts a boolean parameter that controls stripping out comments from the element's children.

There was a small patch required in `schema.go` for the receiver `func (a *Assertion) Element() *etree.Element` to complete the dependency update. Patching up the receiver function to additionally pass `false` to `TransformExcC14n(...)` preserves the function's previous behavior.