### PR TITLE
fix(idp): use a regular expression to capture session id in url

### DIFF
--- a/samlidp/samlidp.go
+++ b/samlidp/samlidp.go
@@ -27,14 +27,14 @@ type Options struct {
 
 // Server represents an IDP server. The server provides the following URLs:
 //
-//    /metadata     - the SAML metadata
-//    /sso          - the SAML endpoint to initiate an authentication flow
-//    /login        - prompt for a username and password if no session established
-//    /login/:shortcut - kick off an IDP-initiated authentication flow
-//    /services     - RESTful interface to Service objects
-//    /users        - RESTful interface to User objects
-//    /sessions     - RESTful interface to Session objects
-//    /shortcuts    - RESTful interface to Shortcut objects
+//     /metadata     - the SAML metadata
+//     /sso          - the SAML endpoint to initiate an authentication flow
+//     /login        - prompt for a username and password if no session established
+//     /login/:shortcut - kick off an IDP-initiated authentication flow
+//     /services     - RESTful interface to Service objects
+//     /users        - RESTful interface to User objects
+//     /sessions     - RESTful interface to Session objects
+//     /shortcuts    - RESTful interface to Shortcut objects
 type Server struct {
 	http.Handler
 	idpConfigMu      sync.RWMutex // protects calls into the IDP

--- a/samlidp/samlidp.go
+++ b/samlidp/samlidp.go
@@ -7,6 +7,7 @@ import (
 	"crypto/x509"
 	"net/http"
 	"net/url"
+	"regexp"
 	"sync"
 
 	"github.com/zenazn/goji/web"
@@ -26,14 +27,14 @@ type Options struct {
 
 // Server represents an IDP server. The server provides the following URLs:
 //
-//     /metadata     - the SAML metadata
-//     /sso          - the SAML endpoint to initiate an authentication flow
-//     /login        - prompt for a username and password if no session established
-//     /login/:shortcut - kick off an IDP-initiated authentication flow
-//     /services     - RESTful interface to Service objects
-//     /users        - RESTful interface to User objects
-//     /sessions     - RESTful interface to Session objects
-//     /shortcuts    - RESTful interface to Shortcut objects
+//	/metadata     - the SAML metadata
+//	/sso          - the SAML endpoint to initiate an authentication flow
+//	/login        - prompt for a username and password if no session established
+//	/login/:shortcut - kick off an IDP-initiated authentication flow
+//	/services     - RESTful interface to Service objects
+//	/users        - RESTful interface to User objects
+//	/sessions     - RESTful interface to Session objects
+//	/shortcuts    - RESTful interface to Shortcut objects
 type Server struct {
 	http.Handler
 	idpConfigMu      sync.RWMutex // protects calls into the IDP
@@ -110,9 +111,10 @@ func (s *Server) InitializeHTTP() {
 	mux.Put("/users/:id", s.HandlePutUser)
 	mux.Delete("/users/:id", s.HandleDeleteUser)
 
+	sessionPath := regexp.MustCompile("/sessions/(?P<id>.*)")
 	mux.Get("/sessions/", s.HandleListSessions)
-	mux.Get("/sessions/:id", s.HandleGetSession)
-	mux.Delete("/sessions/:id", s.HandleDeleteSession)
+	mux.Get(sessionPath, s.HandleGetSession)
+	mux.Delete(sessionPath, s.HandleDeleteSession)
 
 	mux.Get("/shortcuts/", s.HandleListShortcuts)
 	mux.Get("/shortcuts/:id", s.HandleGetShortcut)

--- a/samlidp/samlidp.go
+++ b/samlidp/samlidp.go
@@ -27,14 +27,14 @@ type Options struct {
 
 // Server represents an IDP server. The server provides the following URLs:
 //
-//	/metadata     - the SAML metadata
-//	/sso          - the SAML endpoint to initiate an authentication flow
-//	/login        - prompt for a username and password if no session established
-//	/login/:shortcut - kick off an IDP-initiated authentication flow
-//	/services     - RESTful interface to Service objects
-//	/users        - RESTful interface to User objects
-//	/sessions     - RESTful interface to Session objects
-//	/shortcuts    - RESTful interface to Shortcut objects
+//    /metadata     - the SAML metadata
+//    /sso          - the SAML endpoint to initiate an authentication flow
+//    /login        - prompt for a username and password if no session established
+//    /login/:shortcut - kick off an IDP-initiated authentication flow
+//    /services     - RESTful interface to Service objects
+//    /users        - RESTful interface to User objects
+//    /sessions     - RESTful interface to Session objects
+//    /shortcuts    - RESTful interface to Shortcut objects
 type Server struct {
 	http.Handler
 	idpConfigMu      sync.RWMutex // protects calls into the IDP


### PR DESCRIPTION
In the routes definition of the IdP, the current pattern used to capture session ids (`:id`) fails when the id contains a `/` (which occurs rather often) as it is treated as a path separator rather than part of the argument, which leads to 404 errors. This PR fixes this by using a regexp instead.