### PR TITLE
Fix to allow IDP Initiated logins to not rely on inexistent tracked request cookie

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/crewjam/saml
+module github.com/chrisrollins65/saml
 
 go 1.16
 

--- a/go.mod
+++ b/go.mod
@@ -14,5 +14,3 @@ require (
 	golang.org/x/crypto v0.0.0-20220128200615-198e4374d7ed
 	gotest.tools v2.2.0+incompatible
 )
-
-replace github.com/crewjam/saml => github.com/chrisrollins65/saml v1.0.2

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/chrisrollins65/saml
+module github.com/crewjam/saml
 
 go 1.16
 
@@ -14,3 +14,5 @@ require (
 	golang.org/x/crypto v0.0.0-20220128200615-198e4374d7ed
 	gotest.tools v2.2.0+incompatible
 )
+
+replace github.com/crewjam/saml => github.com/chrisrollins65/saml v1.0.2

--- a/samlsp/middleware.go
+++ b/samlsp/middleware.go
@@ -186,12 +186,19 @@ func (m *Middleware) CreateSessionFromAssertion(w http.ResponseWriter, r *http.R
 	if trackedRequestIndex := r.Form.Get("RelayState"); trackedRequestIndex != "" {
 		trackedRequest, err := m.RequestTracker.GetTrackedRequest(r, trackedRequestIndex)
 		if err != nil {
-			m.OnError(w, r, err)
-			return
-		}
-		m.RequestTracker.StopTrackingRequest(w, r, trackedRequestIndex)
+			if err == http.ErrNoCookie && m.ServiceProvider.AllowIDPInitiated {
+				if uri := r.Form.Get("RelayState"); uri != "" {
+					redirectURI = uri
+				}
+			} else {
+				m.OnError(w, r, err)
+				return
+			}
+		} else {
+			m.RequestTracker.StopTrackingRequest(w, r, trackedRequestIndex)
 
-		redirectURI = trackedRequest.URI
+			redirectURI = trackedRequest.URI
+		}
 	}
 
 	if err := m.Session.CreateSession(w, r, assertion); err != nil {
@@ -209,9 +216,8 @@ func (m *Middleware) CreateSessionFromAssertion(w http.ResponseWriter, r *http.R
 //
 // For example:
 //
-//     goji.Use(m.RequireAccount)
-//     goji.Use(RequireAttributeMiddleware("eduPersonAffiliation", "Staff"))
-//
+//	goji.Use(m.RequireAccount)
+//	goji.Use(RequireAttributeMiddleware("eduPersonAffiliation", "Staff"))
 func RequireAttribute(name, value string) func(http.Handler) http.Handler {
 	return func(handler http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Attempting to log in directly from the IDP fails due to the code searching for a cookie that is set by the SP before redirecting to the IDP.

In IDP Initiated logins, the SP never has a chance to set this cookie, so it does not exist when trying to log in, causing the request to fail.

This change will first check if the cookie exists, and if not then check if IDP initiated logins are allowed. If so, it'll set the redirect URI based on the passed Relay State.