### PR TITLE
Add log.Fatal to trivial example

### DIFF
--- a/example/trivial/trivial.go
+++ b/example/trivial/trivial.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"log"
 
 	"github.com/crewjam/saml/samlsp"
 )
@@ -71,5 +72,5 @@ func main() {
 	http.Handle("/hello", samlMiddleware.RequireAccount(app))
 	http.Handle("/saml/", samlMiddleware)
 	http.Handle("/logout", slo)
-	http.ListenAndServe(":8000", nil)
+	log.Fatal(http.ListenAndServe(":8000", nil))
 }


### PR DESCRIPTION
To print out any error messages (e.g. port already in use), rather than silently exiting.