### PR TITLE
Add better error message for missing named cookie

### DIFF
--- a/samlsp/request_tracker_cookie.go
+++ b/samlsp/request_tracker_cookie.go
@@ -97,7 +97,7 @@ func (t CookieRequestTracker) GetTrackedRequests(r *http.Request) []TrackedReque
 func (t CookieRequestTracker) GetTrackedRequest(r *http.Request, index string) (*TrackedRequest, error) {
 	cookie, err := r.Cookie(t.NamePrefix + index)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%s; Named Cookie: %s; Request Header Cookies: %+v", err.Error(), t.NamePrefix+index, r.Cookies())
 	}
 
 	trackedRequest, err := t.Codec.Decode(cookie.Value)


### PR DESCRIPTION
Currently, GetTrackedRequest will return the error message "http: named cookie not present" if a named cookie is not found. This isn't very descriptive as to what cookie was missing or what cookies were present. This commit will append the named cookie and the list of cookies present in the request header to the error message that is returned.