### PR TITLE
add input validation for xml with no root

### DIFF
--- a/service_provider.go
+++ b/service_provider.go
@@ -695,6 +695,10 @@ func (sp *ServiceProvider) ParseXMLArtifactResponse(soapResponseXML []byte, poss
 		retErr.PrivateErr = fmt.Errorf("cannot unmarshal response: %s", err)
 		return nil, retErr
 	}
+	if doc.Root() == nil {
+		retErr.PrivateErr = errors.New("invalid xml: no root")
+		return nil, retErr
+	}
 	if doc.Root().NamespaceURI() != "http://schemas.xmlsoap.org/soap/envelope/" ||
 		doc.Root().Tag != "Envelope" {
 		retErr.PrivateErr = fmt.Errorf("expected a SOAP Envelope")
@@ -800,6 +804,10 @@ func (sp *ServiceProvider) ParseXMLResponse(decodedResponseXML []byte, possibleR
 	doc := etree.NewDocument()
 	if err := doc.ReadFromBytes(decodedResponseXML); err != nil {
 		retErr.PrivateErr = err
+		return nil, retErr
+	}
+	if doc.Root() == nil {
+		retErr.PrivateErr = errors.New("invalid xml: no root")
 		return nil, retErr
 	}
 


### PR DESCRIPTION
Fix for https://github.com/crewjam/saml/issues/468 : Responses may be valid XML documents with no root (e.g. only containing comments and/or whitespace). The `etree.Root()` function may return `nil` in this case, but the subsequent code does not support that and panics.