### PR TITLE
output the cause of authentication error

### DIFF
--- a/service_provider.go
+++ b/service_provider.go
@@ -579,7 +579,7 @@ type InvalidResponseError struct {
 }
 
 func (ivr *InvalidResponseError) Error() string {
-	return fmt.Sprintf("Authentication failed")
+	return fmt.Sprintf("Authentication failed: %s", ivr.PrivateErr)
 }
 
 // ErrBadStatus is returned when the assertion provided is valid but the


### PR DESCRIPTION
I had to add this output to troubleshoot Ping Federate authentication. Not completely sure, if this code is correct, though.