### PR TITLE
Add Option.CookieName which overrides defaultSessionCookieName when set to non-empty.

### DIFF
--- a/samlsp/new.go
+++ b/samlsp/new.go
@@ -28,6 +28,7 @@ type Options struct {
 	ForceAuthn            bool // TODO(ross): this should be *bool
 	RequestedAuthnContext *saml.RequestedAuthnContext
 	CookieSameSite        http.SameSite
+	CookieName            string
 	RelayStateFunc        func(w http.ResponseWriter, r *http.Request) string
 	LogoutBindings        []string
 }
@@ -47,8 +48,12 @@ func DefaultSessionCodec(opts Options) JWTSessionCodec {
 // DefaultSessionProvider returns the default SessionProvider for the provided options,
 // a CookieSessionProvider configured to store sessions in a cookie.
 func DefaultSessionProvider(opts Options) CookieSessionProvider {
+	cookieName := opts.CookieName
+	if cookieName == "" {
+		cookieName = defaultSessionCookieName
+	}
 	return CookieSessionProvider{
-		Name:     defaultSessionCookieName,
+		Name:     cookieName,
 		Domain:   opts.URL.Host,
 		MaxAge:   defaultSessionMaxAge,
 		HTTPOnly: true,

--- a/samlsp/new_test.go
+++ b/samlsp/new_test.go
@@ -1,0 +1,34 @@
+package samlsp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gotest.tools/assert"
+)
+
+func TestNewCanAcceptCookieName(t *testing.T) {
+
+	testCases := []struct {
+		testName   string
+		cookieName string
+		expected   string
+	}{
+		{"Works with alt name", "altCookie", "altCookie"},
+		{"Works with default", "", "token"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.testName, func(t *testing.T) {
+			opts := Options{
+				CookieName: tc.cookieName,
+			}
+			sp, err := New(opts)
+			require.Nil(t, err)
+			cookieProvider := sp.Session.(CookieSessionProvider)
+			assert.Equal(t, tc.expected, cookieProvider.Name)
+
+		})
+	}
+
+}


### PR DESCRIPTION
This patch adds a new option to `Options` which allows the user to specify the name of the cookie that will be used when creating sessions via CookieSessionProvider.