### PR TITLE
Update README example to use displayName attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ import (
 )
 
 func hello(w http.ResponseWriter, r *http.Request) {
-	fmt.Fprintf(w, "Hello, %s!", samlsp.AttributeFromContext(r.Context(), "cn"))
+	fmt.Fprintf(w, "Hello, %s!", samlsp.AttributeFromContext(r.Context(), "displayName"))
 }
 
 func main() {


### PR DESCRIPTION
Great package, just went through the getting started docs and noticed an issue.

Looks like the assertion attributes returned from https://samltest.id have changed and **cn** is no longer included, meaning that the hello function does not return a name as expected.

Example JWT using the demo:

```
{
  "aud": "http://localhost:8000",
  "exp": 1674593145,
  "iat": 1674589545,
  "iss": "http://localhost:8000",
  "nbf": 1674589545,
  "sub": "AAdzZWNyZXQx7NxVYHJFFRw4UvKpGl1OryGBhvN55fPjUn0gxghj1hxVn7EMYUpfVlUxOqJtDaM71rCefli2ws2KUxlNkUUZ9t/vftoJKeM7PyrPHpMP8KUdr4VWD0LvkvRv1yaN1BuNu69jopqm",
  "attr": {
    "SessionIndex": [
      "_1aab96ca96e7326043c3709b75f9043c"
    ],
    "displayName": [
      "Rick Sanchez"
    ],
    "eduPersonEntitlement": [
      "urn:mace:dir:entitlement:common-lib-terms"
    ],
    "givenName": [
      "Rick"
    ],
    "mail": [
      "rsanchez@samltest.id"
    ],
    "role": [
      "manager@Samltest.id"
    ],
    "sn": [
      "Sanchez"
    ],
    "telephoneNumber": [
      "+1-555-555-5515"
    ],
    "uid": [
      "rick"
    ],
    "urn:oasis:names:tc:SAML:attribute:subject-id": [
      "rsanchez@samltest.id"
    ]
  },
  "saml-session": true
}
```