### PR TITLE
initial commit: option to ignore audience restrictions

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -44,7 +44,7 @@ linters:
     - varcheck # Finds unused global variables and constants [fast: true, auto-fix: false]
 linters-settings:
   goimports:
-    local-prefixes: github.com/crewjam/saml
+    local-prefixes: github.com/mnantel/saml
   govet:
     disable:
       - shadow

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # SAML
 
-[![](https://godoc.org/github.com/crewjam/saml?status.svg)](http://godoc.org/github.com/crewjam/saml)
+[![](https://godoc.org/github.com/mnantel/saml?status.svg)](http://godoc.org/github.com/mnantel/saml)
 
-![Build Status](https://github.com/crewjam/saml/workflows/Presubmit/badge.svg)
+![Build Status](https://github.com/mnantel/saml/workflows/Presubmit/badge.svg)
 
 Package saml contains a partial implementation of the SAML standard in golang.
 SAML is a standard for identity federation, i.e. either allowing a third party to authenticate your users or allowing third parties to rely on us to authenticate their users.
@@ -54,7 +54,7 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/crewjam/saml/samlsp"
+	"github.com/mnantel/saml/samlsp"
 )
 
 func hello(w http.ResponseWriter, r *http.Request) {

--- a/example/idp/idp.go
+++ b/example/idp/idp.go
@@ -10,8 +10,8 @@ import (
 	"github.com/zenazn/goji"
 	"golang.org/x/crypto/bcrypt"
 
-	"github.com/crewjam/saml/logger"
-	"github.com/crewjam/saml/samlidp"
+	"github.com/mnantel/saml/logger"
+	"github.com/mnantel/saml/samlidp"
 )
 
 var key = func() crypto.PrivateKey {

--- a/example/service.go
+++ b/example/service.go
@@ -19,7 +19,7 @@ import (
 	"github.com/zenazn/goji"
 	"github.com/zenazn/goji/web"
 
-	"github.com/crewjam/saml/samlsp"
+	"github.com/mnantel/saml/samlsp"
 )
 
 var links = map[string]Link{}

--- a/example/trivial/trivial.go
+++ b/example/trivial/trivial.go
@@ -10,7 +10,7 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/crewjam/saml/samlsp"
+	"github.com/mnantel/saml/samlsp"
 )
 
 var samlMiddleware *samlsp.Middleware

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
+replace github.com/crewjam/saml => github.com/mnantel/saml v1.0.0
+
 module github.com/crewjam/saml
 
 go 1.16

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 replace github.com/crewjam/saml => github.com/mnantel/saml v1.0.0
 
-module github.com/crewjam/saml
+module github.com/mnantel/saml
 
 go 1.16
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,3 @@
-replace github.com/crewjam/saml => github.com/mnantel/saml v1.0.0
 
 module github.com/mnantel/saml
 

--- a/identity_provider.go
+++ b/identity_provider.go
@@ -22,8 +22,8 @@ import (
 	xrv "github.com/mattermost/xml-roundtrip-validator"
 	dsig "github.com/russellhaering/goxmldsig"
 
-	"github.com/crewjam/saml/logger"
-	"github.com/crewjam/saml/xmlenc"
+	"github.com/mnantel/saml/logger"
+	"github.com/mnantel/saml/xmlenc"
 )
 
 // Session represents a user session. It is returned by the

--- a/identity_provider_test.go
+++ b/identity_provider_test.go
@@ -26,9 +26,9 @@ import (
 	"github.com/beevik/etree"
 	"github.com/golang-jwt/jwt/v4"
 
-	"github.com/crewjam/saml/logger"
-	"github.com/crewjam/saml/testsaml"
-	"github.com/crewjam/saml/xmlenc"
+	"github.com/mnantel/saml/logger"
+	"github.com/mnantel/saml/testsaml"
+	"github.com/mnantel/saml/xmlenc"
 )
 
 type IdentityProviderTest struct {

--- a/saml.go
+++ b/saml.go
@@ -11,7 +11,7 @@
 //
 // Version 0.4.0 introduces a few breaking changes to the _samlsp_ package in order to make the package more extensible, and to clean up the interfaces a bit. The default behavior remains the same, but you can now provide interface implementations of _RequestTracker_ (which tracks pending requests), _Session_ (which handles maintaining a session) and _OnError_ which handles reporting errors.
 //
-// Public fields of _samlsp.Middleware_ have changed, so some usages may require adjustment. See [issue 231](https://github.com/crewjam/saml/issues/231) for details.
+// Public fields of _samlsp.Middleware_ have changed, so some usages may require adjustment. See [issue 231](https://github.com/mnantel/saml/issues/231) for details.
 //
 // The option to provide an IDP metadata URL has been deprecated. Instead, we recommend that you use the `FetchMetadata()` function, or fetch the metadata yourself and use the new `ParseMetadata()` function, and pass the metadata in _samlsp.Options.IDPMetadata_.
 //
@@ -76,7 +76,7 @@
 //	"net/http"
 //	"net/url"
 //
-//	"github.com/crewjam/saml/samlsp"
+//	"github.com/mnantel/saml/samlsp"
 //
 // )
 //

--- a/samlidp/samlidp.go
+++ b/samlidp/samlidp.go
@@ -12,8 +12,8 @@ import (
 
 	"github.com/zenazn/goji/web"
 
-	"github.com/crewjam/saml"
-	"github.com/crewjam/saml/logger"
+	"github.com/mnantel/saml"
+	"github.com/mnantel/saml/logger"
 )
 
 // Options represent the parameters to New() for creating a new IDP server

--- a/samlidp/samlidp_test.go
+++ b/samlidp/samlidp_test.go
@@ -18,8 +18,8 @@ import (
 
 	"github.com/golang-jwt/jwt/v4"
 
-	"github.com/crewjam/saml"
-	"github.com/crewjam/saml/logger"
+	"github.com/mnantel/saml"
+	"github.com/mnantel/saml/logger"
 )
 
 type testRandomReader struct {

--- a/samlidp/service.go
+++ b/samlidp/service.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/zenazn/goji/web"
 
-	"github.com/crewjam/saml"
+	"github.com/mnantel/saml"
 )
 
 // Service represents a configured SP for whom this IDP provides authentication services.

--- a/samlidp/session.go
+++ b/samlidp/session.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/zenazn/goji/web"
 
-	"github.com/crewjam/saml"
+	"github.com/mnantel/saml"
 )
 
 var sessionMaxAge = time.Hour

--- a/samlidp/util.go
+++ b/samlidp/util.go
@@ -9,7 +9,7 @@ import (
 
 	xrv "github.com/mattermost/xml-roundtrip-validator"
 
-	"github.com/crewjam/saml"
+	"github.com/mnantel/saml"
 )
 
 func randomBytes(n int) []byte {

--- a/samlsp/error.go
+++ b/samlsp/error.go
@@ -4,7 +4,7 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/crewjam/saml"
+	"github.com/mnantel/saml"
 )
 
 // ErrorFunction is a callback that is invoked to return an error to the

--- a/samlsp/fetch_metadata.go
+++ b/samlsp/fetch_metadata.go
@@ -12,7 +12,7 @@ import (
 	"github.com/crewjam/httperr"
 	xrv "github.com/mattermost/xml-roundtrip-validator"
 
-	"github.com/crewjam/saml"
+	"github.com/mnantel/saml"
 )
 
 // ParseMetadata parses arbitrary SAML IDP metadata.

--- a/samlsp/middleware.go
+++ b/samlsp/middleware.go
@@ -4,7 +4,7 @@ import (
 	"encoding/xml"
 	"net/http"
 
-	"github.com/crewjam/saml"
+	"github.com/mnantel/saml"
 )
 
 // Middleware implements middleware than allows a web application

--- a/samlsp/middleware_test.go
+++ b/samlsp/middleware_test.go
@@ -23,8 +23,8 @@ import (
 	is "gotest.tools/assert/cmp"
 	"gotest.tools/golden"
 
-	"github.com/crewjam/saml"
-	"github.com/crewjam/saml/testsaml"
+	"github.com/mnantel/saml"
+	"github.com/mnantel/saml/testsaml"
 )
 
 type MiddlewareTest struct {

--- a/samlsp/new.go
+++ b/samlsp/new.go
@@ -28,6 +28,7 @@ type Options struct {
 	ForceAuthn            bool // TODO(ross): this should be *bool
 	RequestedAuthnContext *saml.RequestedAuthnContext
 	CookieSameSite        http.SameSite
+	IgnoreAudience        bool
 	CookieName            string
 	RelayStateFunc        func(w http.ResponseWriter, r *http.Request) string
 	LogoutBindings        []string
@@ -123,6 +124,7 @@ func DefaultServiceProvider(opts Options) saml.ServiceProvider {
 		SloURL:                *sloURL,
 		IDPMetadata:           opts.IDPMetadata,
 		ForceAuthn:            forceAuthn,
+		IgnoreAudience:        opts.IgnoreAudience,
 		RequestedAuthnContext: opts.RequestedAuthnContext,
 		SignatureMethod:       signatureMethod,
 		AllowIDPInitiated:     opts.AllowIDPInitiated,

--- a/samlsp/new.go
+++ b/samlsp/new.go
@@ -9,7 +9,7 @@ import (
 
 	dsig "github.com/russellhaering/goxmldsig"
 
-	"github.com/crewjam/saml"
+	"github.com/mnantel/saml"
 )
 
 // Options represents the parameters for creating a new middleware

--- a/samlsp/request_tracker_cookie.go
+++ b/samlsp/request_tracker_cookie.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/crewjam/saml"
+	"github.com/mnantel/saml"
 )
 
 var _ RequestTracker = CookieRequestTracker{}

--- a/samlsp/request_tracker_jwt.go
+++ b/samlsp/request_tracker_jwt.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/golang-jwt/jwt/v4"
 
-	"github.com/crewjam/saml"
+	"github.com/mnantel/saml"
 )
 
 var defaultJWTSigningMethod = jwt.SigningMethodRS256

--- a/samlsp/session.go
+++ b/samlsp/session.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/crewjam/saml"
+	"github.com/mnantel/saml"
 )
 
 // Session is an interface implemented to contain a session.

--- a/samlsp/session_cookie.go
+++ b/samlsp/session_cookie.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/crewjam/saml"
+	"github.com/mnantel/saml"
 )
 
 const defaultSessionCookieName = "token"

--- a/samlsp/session_cookie_test.go
+++ b/samlsp/session_cookie_test.go
@@ -8,7 +8,7 @@ import (
 	"gotest.tools/assert"
 	is "gotest.tools/assert/cmp"
 
-	"github.com/crewjam/saml"
+	"github.com/mnantel/saml"
 )
 
 func TestCookieSameSite(t *testing.T) {

--- a/samlsp/session_jwt.go
+++ b/samlsp/session_jwt.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	defaultSessionMaxAge  = 0
+	defaultSessionMaxAge  = time.Hour * 12
 	claimNameSessionIndex = "SessionIndex"
 )
 

--- a/samlsp/session_jwt.go
+++ b/samlsp/session_jwt.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/golang-jwt/jwt/v4"
 
-	"github.com/crewjam/saml"
+	"github.com/mnantel/saml"
 )
 
 const (

--- a/samlsp/session_jwt.go
+++ b/samlsp/session_jwt.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	defaultSessionMaxAge  = time.Hour
+	defaultSessionMaxAge  = time.Hour * 12
 	claimNameSessionIndex = "SessionIndex"
 )
 

--- a/samlsp/session_jwt.go
+++ b/samlsp/session_jwt.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	defaultSessionMaxAge  = time.Hour * 12
+	defaultSessionMaxAge  = 0
 	claimNameSessionIndex = "SessionIndex"
 )
 

--- a/samlsp/util.go
+++ b/samlsp/util.go
@@ -3,7 +3,7 @@ package samlsp
 import (
 	"io"
 
-	"github.com/crewjam/saml"
+	"github.com/mnantel/saml"
 )
 
 func randomBytes(n int) []byte {

--- a/service_provider.go
+++ b/service_provider.go
@@ -23,7 +23,7 @@ import (
 	dsig "github.com/russellhaering/goxmldsig"
 	"github.com/russellhaering/goxmldsig/etreeutils"
 
-	"github.com/crewjam/saml/xmlenc"
+	"github.com/mnantel/saml/xmlenc"
 )
 
 // NameIDFormat is the format of the id

--- a/service_provider.go
+++ b/service_provider.go
@@ -109,6 +109,9 @@ type ServiceProvider struct {
 	// AllowIdpInitiated
 	AllowIDPInitiated bool
 
+	// Ignore audience restrictions
+	IgnoreAudience bool
+
 	// DefaultRedirectURI where untracked requests (as of IDPInitiated) are redirected to
 	DefaultRedirectURI string
 
@@ -1072,7 +1075,8 @@ func (sp *ServiceProvider) validateAssertion(assertion *Assertion, possibleReque
 			audienceRestrictionsValid = true
 		}
 	}
-	if !audienceRestrictionsValid {
+
+	if !audienceRestrictionsValid && !sp.IgnoreAudience {
 		return fmt.Errorf("assertion Conditions AudienceRestriction does not contain %q", audience)
 	}
 	return nil

--- a/service_provider_test.go
+++ b/service_provider_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/beevik/etree"
 	dsig "github.com/russellhaering/goxmldsig"
 
-	"github.com/crewjam/saml/testsaml"
+	"github.com/mnantel/saml/testsaml"
 )
 
 type ServiceProviderTest struct {


### PR DESCRIPTION
I originally forked and removed audience restriction checking, but figure I should probably do the right thing and submit a pull request.

This is the first time ever I do this on Github - please let me know if anything is wrong.

One of the projects I work on has a great deal of hostname variances and as SAML is used strictly for authentication, and not at all for authorization, I require ignoring audience restrictions completely to facilitate the use case.

I have added an option to do just that. I think I added all the parts correctly, but please let me know if this is wrong.