### PR TITLE
Fix decoding SAMLResponse for logout requests

### DIFF
--- a/service_provider.go
+++ b/service_provider.go
@@ -1535,7 +1535,7 @@ func (sp *ServiceProvider) ValidateLogoutResponseRedirect(queryParameterData str
 	}
 
 	doc := etree.NewDocument()
-	if err := doc.ReadFromBytes(rawResponseBuf); err != nil {
+	if err := doc.ReadFromBytes(gr); err != nil {
 		retErr.PrivateErr = err
 		return retErr
 	}


### PR DESCRIPTION
In https://github.com/crewjam/saml/commit/aee3fb1edeeaf1088fcb458727e0fd863d277f8b, a bug was introduced that breaks validating logout responses if it's in the query string. The code reads the raw input rather than the deflated version, causing validation to fail.