### PR TITLE
Update golangci-lint version, linting fixes.

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,4 +15,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.46.2
+          version: v1.52.2

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,41 +7,35 @@
 
 linters:
   enable:
+    - bodyclose # checks whether HTTP response body is closed successfully [fast: false, auto-fix: false]
+    - depguard # Go linter that checks if package imports are in a list of acceptable packages [fast: true, auto-fix: false]
+    - errcheck # Inspects source code for security problems [fast: true, auto-fix: false]
+    - gocritic # The most opinionated Go source code linter [fast: true, auto-fix: false]
+    - gocyclo # Computes and checks the cyclomatic complexity of functions [fast: true, auto-fix: false]
     - gofmt # Gofmt checks whether code was gofmt-ed. By default this tool runs with -s option to check for code simplification [fast: true, auto-fix: true]
     - goimports # Goimports does everything that gofmt does. Additionally it checks unused imports [fast: true, auto-fix: true]
     - gosec # Errcheck is a program for checking for unchecked errors in go programs. These unchecked errors can be critical bugs in some cases [fast: true, auto-fix: false]
-    - misspell # Finds commonly misspelled English words in comments [fast: true, auto-fix: true]
-    - deadcode # Finds unused code [fast: true, auto-fix: false]
-    - revive # Golint differs from gofmt. Gofmt reformats Go source code, whereas golint prints out style mistakes [fast: true, auto-fix: false]
-    - unconvert # Remove unnecessary type conversions [fast: true, auto-fix: false]
-
-  disable:
-    # TODO(ross): fix errors reported by these checkers and enable them
-    - bodyclose # checks whether HTTP response body is closed successfully [fast: false, auto-fix: false]
-    - depguard # Go linter that checks if package imports are in a list of acceptable packages [fast: true, auto-fix: false]
-    - dupl # Tool for code clone detection [fast: true, auto-fix: false]
-    - errcheck # Inspects source code for security problems [fast: true, auto-fix: false]
-    - gochecknoglobals # Checks that no globals are present in Go code [fast: true, auto-fix: false]
-    - gochecknoinits # Checks that no init functions are present in Go code [fast: true, auto-fix: false]
-    - goconst # Finds repeated strings that could be replaced by a constant [fast: true, auto-fix: false]
-    - gocritic # The most opinionated Go source code linter [fast: true, auto-fix: false]
-    - gocyclo # Computes and checks the cyclomatic complexity of functions [fast: true, auto-fix: false]
     - gosimple # Linter for Go source code that specializes in simplifying a code [fast: false, auto-fix: false]
     - govet # Vet examines Go source code and reports suspicious constructs, such as Printf calls whose arguments do not align with the format string [fast: false, auto-fix: false]
     - ineffassign # Detects when assignments to existing variables are not used [fast: true, auto-fix: false]
-    - interfacer # Linter that suggests narrower interface types [fast: false, auto-fix: false]
-    - lll # Reports long lines [fast: true, auto-fix: false]
-    - maligned # Tool to detect Go structs that would take less memory if their fields were sorted [fast: true, auto-fix: false]
+    - misspell # Finds commonly misspelled English words in comments [fast: true, auto-fix: true]
     - nakedret # Finds naked returns in functions greater than a specified function length [fast: true, auto-fix: false]
     - prealloc # Finds slice declarations that could potentially be preallocated [fast: true, auto-fix: false]
-    - scopelint # Scopelint checks for unpinned variables in go programs [fast: true, auto-fix: false]
+    - revive # Golint differs from gofmt. Gofmt reformats Go source code, whereas golint prints out style mistakes [fast: true, auto-fix: false]
     - staticcheck # Staticcheck is a go vet on steroids, applying a ton of static analysis checks [fast: false, auto-fix: false]
-    - structcheck # Finds unused struct fields [fast: true, auto-fix: false]
     - stylecheck # Stylecheck is a replacement for golint [fast: false, auto-fix: false]
     - typecheck # Like the front-end of a Go compiler, parses and type-checks Go code [fast: true, auto-fix: false]
+    - unconvert # Remove unnecessary type conversions [fast: true, auto-fix: false]
     - unparam # Reports unused function parameters [fast: false, auto-fix: false]
     - unused # Checks Go code for unused constants, variables, functions and types [fast: false, auto-fix: false]
-    - varcheck # Finds unused global variables and constants [fast: true, auto-fix: false]
+
+  disable:
+    # TODO(ross): fix errors reported by these checkers and enable them
+    - dupl # Tool for code clone detection [fast: true, auto-fix: false]
+    - gochecknoglobals # Checks that no globals are present in Go code [fast: true, auto-fix: false]
+    - gochecknoinits # Checks that no init functions are present in Go code [fast: true, auto-fix: false]
+    - goconst # Finds repeated strings that could be replaced by a constant [fast: true, auto-fix: false]
+    - lll # Reports long lines [fast: true, auto-fix: false]
 linters-settings:
   goimports:
     local-prefixes: github.com/crewjam/saml

--- a/example/idp/idp.go
+++ b/example/idp/idp.go
@@ -1,3 +1,4 @@
+// Package main contains an example identity provider implementation.
 package main
 
 import (

--- a/example/trivial/trivial.go
+++ b/example/trivial/trivial.go
@@ -1,3 +1,4 @@
+// Package main contains an example service provider implementation.
 package main
 
 import (
@@ -9,6 +10,7 @@ import (
 	"log"
 	"net/http"
 	"net/url"
+	"time"
 
 	"github.com/crewjam/saml/samlsp"
 )
@@ -69,8 +71,14 @@ func main() {
 	})
 	app := http.HandlerFunc(hello)
 	slo := http.HandlerFunc(logout)
+
 	http.Handle("/hello", samlMiddleware.RequireAccount(app))
 	http.Handle("/saml/", samlMiddleware)
 	http.Handle("/logout", slo)
-	log.Fatal(http.ListenAndServe(":8000", nil))
+
+	server := &http.Server{
+		Addr:              ":8080",
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+	log.Fatal(server.ListenAndServe())
 }

--- a/identity_provider_go117_test.go
+++ b/identity_provider_go117_test.go
@@ -43,8 +43,10 @@ func TestIDPHTTPCanHandleSSORequest(t *testing.T) {
 		d := bytes.Replace(c, []byte("<AuthnRequest"), []byte("<AuthnRequest ::foo=\"bar\">]]"), 1)
 		f := bytes.Buffer{}
 		e, _ := flate.NewWriter(&f, flate.DefaultCompression)
-		e.Write(d)
-		e.Close()
+		_, err := e.Write(d)
+		assert.Check(t, err)
+		err = e.Close()
+		assert.Check(t, err)
 		g := base64.StdEncoding.EncodeToString(f.Bytes())
 		invalidRequest := url.QueryEscape(g)
 

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -1,3 +1,4 @@
+// Package logger provides a logging interface.
 package logger
 
 import (

--- a/metadata.go
+++ b/metadata.go
@@ -65,7 +65,7 @@ type EntityDescriptor struct {
 }
 
 // MarshalXML implements xml.Marshaler
-func (m EntityDescriptor) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+func (m EntityDescriptor) MarshalXML(e *xml.Encoder, _ xml.StartElement) error {
 	type Alias EntityDescriptor
 	aux := &struct {
 		ValidUntil    RelaxedTime `xml:"validUntil,attr,omitempty"`

--- a/samlidp/samlidp.go
+++ b/samlidp/samlidp.go
@@ -47,9 +47,9 @@ type Server struct {
 // New returns a new Server
 func New(opts Options) (*Server, error) {
 	metadataURL := opts.URL
-	metadataURL.Path = metadataURL.Path + "/metadata"
+	metadataURL.Path += "/metadata"
 	ssoURL := opts.URL
-	ssoURL.Path = ssoURL.Path + "/sso"
+	ssoURL.Path += "/sso"
 	logr := opts.Logger
 	if logr == nil {
 		logr = logger.DefaultLogger

--- a/samlidp/samlidp_test.go
+++ b/samlidp/samlidp_test.go
@@ -124,8 +124,8 @@ func TestHTTPCanHandleMetadataRequest(t *testing.T) {
 	test.Server.ServeHTTP(w, r)
 	assert.Check(t, is.Equal(http.StatusOK, w.Code))
 	assert.Check(t,
-		strings.HasPrefix(string(w.Body.Bytes()), "<EntityDescriptor"),
-		string(w.Body.Bytes()))
+		strings.HasPrefix(w.Body.String(), "<EntityDescriptor"),
+		w.Body.String())
 	golden.Assert(t, w.Body.String(), "http_metadata_response.html")
 }
 
@@ -139,7 +139,7 @@ func TestHTTPCanSSORequest(t *testing.T) {
 	test.Server.ServeHTTP(w, r)
 	assert.Check(t, is.Equal(http.StatusOK, w.Code))
 	assert.Check(t,
-		strings.HasPrefix(string(w.Body.Bytes()), "<html><p></p><form method=\"post\" action=\"https://idp.example.com/sso\">"),
-		string(w.Body.Bytes()))
+		strings.HasPrefix(w.Body.String(), "<html><p></p><form method=\"post\" action=\"https://idp.example.com/sso\">"),
+		w.Body.String())
 	golden.Assert(t, w.Body.String(), "http_sso_response.html")
 }

--- a/samlidp/service_test.go
+++ b/samlidp/service_test.go
@@ -18,7 +18,7 @@ func TestServicesCrud(t *testing.T) {
 	r, _ := http.NewRequest("GET", "https://idp.example.com/services/", nil)
 	test.Server.ServeHTTP(w, r)
 	assert.Check(t, is.Equal(http.StatusOK, w.Code))
-	assert.Check(t, is.Equal("{\"services\":[]}\n", string(w.Body.Bytes())))
+	assert.Check(t, is.Equal("{\"services\":[]}\n", w.Body.String()))
 
 	w = httptest.NewRecorder()
 	r, _ = http.NewRequest("PUT", "https://idp.example.com/services/sp",
@@ -36,7 +36,7 @@ func TestServicesCrud(t *testing.T) {
 	r, _ = http.NewRequest("GET", "https://idp.example.com/services/", nil)
 	test.Server.ServeHTTP(w, r)
 	assert.Check(t, is.Equal(http.StatusOK, w.Code))
-	assert.Check(t, is.Equal("{\"services\":[\"sp\"]}\n", string(w.Body.Bytes())))
+	assert.Check(t, is.Equal("{\"services\":[\"sp\"]}\n", w.Body.String()))
 
 	assert.Check(t, is.Len(test.Server.serviceProviders, 2))
 
@@ -49,6 +49,6 @@ func TestServicesCrud(t *testing.T) {
 	r, _ = http.NewRequest("GET", "https://idp.example.com/services/", nil)
 	test.Server.ServeHTTP(w, r)
 	assert.Check(t, is.Equal(http.StatusOK, w.Code))
-	assert.Check(t, is.Equal("{\"services\":[]}\n", string(w.Body.Bytes())))
+	assert.Check(t, is.Equal("{\"services\":[]}\n", w.Body.String()))
 	assert.Check(t, is.Len(test.Server.serviceProviders, 1))
 }

--- a/samlidp/session.go
+++ b/samlidp/session.go
@@ -48,12 +48,13 @@ func (s *Server) GetSession(w http.ResponseWriter, r *http.Request, req *saml.Id
 		}
 
 		session := &saml.Session{
-			ID:                    base64.StdEncoding.EncodeToString(randomBytes(32)),
-			NameID:                user.Email,
-			CreateTime:            saml.TimeNow(),
-			ExpireTime:            saml.TimeNow().Add(sessionMaxAge),
-			Index:                 hex.EncodeToString(randomBytes(32)),
-			UserName:              user.Name,
+			ID:         base64.StdEncoding.EncodeToString(randomBytes(32)),
+			NameID:     user.Email,
+			CreateTime: saml.TimeNow(),
+			ExpireTime: saml.TimeNow().Add(sessionMaxAge),
+			Index:      hex.EncodeToString(randomBytes(32)),
+			UserName:   user.Name,
+			// nolint:gocritic // Groups should be a slice here.
 			Groups:                user.Groups[:],
 			UserEmail:             user.Email,
 			UserCommonName:        user.CommonName,
@@ -102,7 +103,7 @@ func (s *Server) GetSession(w http.ResponseWriter, r *http.Request, req *saml.Id
 // sendLoginForm produces a form which requests a username and password and directs the user
 // back to the IDP authorize URL to restart the SAML login flow, this time establishing a
 // session based on the credentials that were provided.
-func (s *Server) sendLoginForm(w http.ResponseWriter, r *http.Request, req *saml.IdpAuthnRequest, toast string) {
+func (s *Server) sendLoginForm(w http.ResponseWriter, _ *http.Request, req *saml.IdpAuthnRequest, toast string) {
 	tmpl := template.Must(template.New("saml-post-form").Parse(`` +
 		`<html>` +
 		`<p>{{.Toast}}</p>` +
@@ -135,7 +136,7 @@ func (s *Server) sendLoginForm(w http.ResponseWriter, r *http.Request, req *saml
 // in the request body, then they are validated. For valid credentials, the response is a
 // 200 OK and the JSON session object. For invalid credentials, the HTML login prompt form
 // is sent.
-func (s *Server) HandleLogin(c web.C, w http.ResponseWriter, r *http.Request) {
+func (s *Server) HandleLogin(_ web.C, w http.ResponseWriter, r *http.Request) {
 	if err := r.ParseForm(); err != nil {
 		http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
 		return
@@ -144,38 +145,48 @@ func (s *Server) HandleLogin(c web.C, w http.ResponseWriter, r *http.Request) {
 	if session == nil {
 		return
 	}
-	json.NewEncoder(w).Encode(session)
+	if err := json.NewEncoder(w).Encode(session); err != nil {
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		return
+	}
 }
 
 // HandleListSessions handles the `GET /sessions/` request and responds with a JSON formatted list
 // of session names.
-func (s *Server) HandleListSessions(c web.C, w http.ResponseWriter, r *http.Request) {
+func (s *Server) HandleListSessions(_ web.C, w http.ResponseWriter, _ *http.Request) {
 	sessions, err := s.Store.List("/sessions/")
 	if err != nil {
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return
 	}
 
-	json.NewEncoder(w).Encode(struct {
+	err = json.NewEncoder(w).Encode(struct {
 		Sessions []string `json:"sessions"`
 	}{Sessions: sessions})
+	if err != nil {
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		return
+	}
 }
 
 // HandleGetSession handles the `GET /sessions/:id` request and responds with the session
 // object in JSON format.
-func (s *Server) HandleGetSession(c web.C, w http.ResponseWriter, r *http.Request) {
+func (s *Server) HandleGetSession(c web.C, w http.ResponseWriter, _ *http.Request) {
 	session := saml.Session{}
 	err := s.Store.Get(fmt.Sprintf("/sessions/%s", c.URLParams["id"]), &session)
 	if err != nil {
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return
 	}
-	json.NewEncoder(w).Encode(session)
+	if err := json.NewEncoder(w).Encode(session); err != nil {
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		return
+	}
 }
 
 // HandleDeleteSession handles the `DELETE /sessions/:id` request. It invalidates the
 // specified session.
-func (s *Server) HandleDeleteSession(c web.C, w http.ResponseWriter, r *http.Request) {
+func (s *Server) HandleDeleteSession(c web.C, w http.ResponseWriter, _ *http.Request) {
 	err := s.Store.Delete(fmt.Sprintf("/sessions/%s", c.URLParams["id"]))
 	if err != nil {
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)

--- a/samlidp/session_test.go
+++ b/samlidp/session_test.go
@@ -17,7 +17,7 @@ func TestSessionsCrud(t *testing.T) {
 	test.Server.ServeHTTP(w, r)
 	assert.Check(t, is.Equal(http.StatusOK, w.Code))
 	assert.Check(t, is.Equal("{\"sessions\":[]}\n",
-		string(w.Body.Bytes())))
+		w.Body.String()))
 
 	w = httptest.NewRecorder()
 	r, _ = http.NewRequest("PUT", "https://idp.example.com/users/alice",
@@ -34,7 +34,7 @@ func TestSessionsCrud(t *testing.T) {
 	assert.Check(t, is.Equal("session=AAIEBggKDA4QEhQWGBocHiAiJCYoKiwuMDI0Njg6PD4=; Path=/; Max-Age=3600; HttpOnly; Secure",
 		w.Header().Get("Set-Cookie")))
 	assert.Check(t, is.Equal("{\"ID\":\"AAIEBggKDA4QEhQWGBocHiAiJCYoKiwuMDI0Njg6PD4=\",\"CreateTime\":\"2015-12-01T01:57:09Z\",\"ExpireTime\":\"2015-12-01T02:57:09Z\",\"Index\":\"40424446484a4c4e50525456585a5c5e60626466686a6c6e70727476787a7c7e\",\"NameID\":\"\",\"NameIDFormat\":\"\",\"SubjectID\":\"\",\"Groups\":null,\"UserName\":\"alice\",\"UserEmail\":\"\",\"UserCommonName\":\"\",\"UserSurname\":\"\",\"UserGivenName\":\"\",\"UserScopedAffiliation\":\"\",\"CustomAttributes\":null}\n",
-		string(w.Body.Bytes())))
+		w.Body.String()))
 
 	w = httptest.NewRecorder()
 	r, _ = http.NewRequest("GET", "https://idp.example.com/login", nil)
@@ -42,14 +42,14 @@ func TestSessionsCrud(t *testing.T) {
 	test.Server.ServeHTTP(w, r)
 	assert.Check(t, is.Equal(http.StatusOK, w.Code))
 	assert.Check(t, is.Equal("{\"ID\":\"AAIEBggKDA4QEhQWGBocHiAiJCYoKiwuMDI0Njg6PD4=\",\"CreateTime\":\"2015-12-01T01:57:09Z\",\"ExpireTime\":\"2015-12-01T02:57:09Z\",\"Index\":\"40424446484a4c4e50525456585a5c5e60626466686a6c6e70727476787a7c7e\",\"NameID\":\"\",\"NameIDFormat\":\"\",\"SubjectID\":\"\",\"Groups\":null,\"UserName\":\"alice\",\"UserEmail\":\"\",\"UserCommonName\":\"\",\"UserSurname\":\"\",\"UserGivenName\":\"\",\"UserScopedAffiliation\":\"\",\"CustomAttributes\":null}\n",
-		string(w.Body.Bytes())))
+		w.Body.String()))
 
 	w = httptest.NewRecorder()
 	r, _ = http.NewRequest("GET", "https://idp.example.com/sessions/AAIEBggKDA4QEhQWGBocHiAiJCYoKiwuMDI0Njg6PD4=", nil)
 	test.Server.ServeHTTP(w, r)
 	assert.Check(t, is.Equal(http.StatusOK, w.Code))
 	assert.Check(t, is.Equal("{\"ID\":\"AAIEBggKDA4QEhQWGBocHiAiJCYoKiwuMDI0Njg6PD4=\",\"CreateTime\":\"2015-12-01T01:57:09Z\",\"ExpireTime\":\"2015-12-01T02:57:09Z\",\"Index\":\"40424446484a4c4e50525456585a5c5e60626466686a6c6e70727476787a7c7e\",\"NameID\":\"\",\"NameIDFormat\":\"\",\"SubjectID\":\"\",\"Groups\":null,\"UserName\":\"alice\",\"UserEmail\":\"\",\"UserCommonName\":\"\",\"UserSurname\":\"\",\"UserGivenName\":\"\",\"UserScopedAffiliation\":\"\",\"CustomAttributes\":null}\n",
-		string(w.Body.Bytes())))
+		w.Body.String()))
 
 	w = httptest.NewRecorder()
 	r, _ = http.NewRequest("DELETE", "https://idp.example.com/sessions/AAIEBggKDA4QEhQWGBocHiAiJCYoKiwuMDI0Njg6PD4=", nil)
@@ -61,6 +61,6 @@ func TestSessionsCrud(t *testing.T) {
 	test.Server.ServeHTTP(w, r)
 	assert.Check(t, is.Equal(http.StatusOK, w.Code))
 	assert.Check(t, is.Equal("{\"sessions\":[]}\n",
-		string(w.Body.Bytes())))
+		w.Body.String()))
 
 }

--- a/samlidp/shortcut_test.go
+++ b/samlidp/shortcut_test.go
@@ -17,7 +17,7 @@ func TestShortcutsCrud(t *testing.T) {
 	test.Server.ServeHTTP(w, r)
 	assert.Check(t, is.Equal(http.StatusOK, w.Code))
 	assert.Check(t, is.Equal("{\"shortcuts\":[]}\n",
-		string(w.Body.Bytes())))
+		w.Body.String()))
 
 	w = httptest.NewRecorder()
 	r, _ = http.NewRequest("PUT", "https://idp.example.com/shortcuts/bob",
@@ -30,14 +30,14 @@ func TestShortcutsCrud(t *testing.T) {
 	test.Server.ServeHTTP(w, r)
 	assert.Check(t, is.Equal(http.StatusOK, w.Code))
 	assert.Check(t, is.Equal("{\"name\":\"bob\",\"service_provider\":\"https://example.com/saml2/metadata\",\"url_suffix_as_relay_state\":true}\n",
-		string(w.Body.Bytes())))
+		w.Body.String()))
 
 	w = httptest.NewRecorder()
 	r, _ = http.NewRequest("GET", "https://idp.example.com/shortcuts/", nil)
 	test.Server.ServeHTTP(w, r)
 	assert.Check(t, is.Equal(http.StatusOK, w.Code))
 	assert.Check(t, is.Equal("{\"shortcuts\":[\"bob\"]}\n",
-		string(w.Body.Bytes())))
+		w.Body.String()))
 
 	w = httptest.NewRecorder()
 	r, _ = http.NewRequest("DELETE", "https://idp.example.com/shortcuts/bob", nil)
@@ -49,7 +49,7 @@ func TestShortcutsCrud(t *testing.T) {
 	test.Server.ServeHTTP(w, r)
 	assert.Check(t, is.Equal(http.StatusOK, w.Code))
 	assert.Check(t, is.Equal("{\"shortcuts\":[]}\n",
-		string(w.Body.Bytes())))
+		w.Body.String()))
 }
 
 func TestShortcut(t *testing.T) {
@@ -78,7 +78,7 @@ func TestShortcut(t *testing.T) {
 	r.Header.Set("Cookie", "session=AAIEBggKDA4QEhQWGBocHiAiJCYoKiwuMDI0Njg6PD4=")
 	test.Server.ServeHTTP(w, r)
 	assert.Check(t, is.Equal(http.StatusOK, w.Code))
-	body := string(w.Body.Bytes())
+	body := w.Body.String()
 
 	assert.Check(t, strings.Contains(body,
 		"<input type=\"hidden\" name=\"RelayState\" value=\"/whoami\" />"),

--- a/samlidp/user_test.go
+++ b/samlidp/user_test.go
@@ -16,7 +16,7 @@ func TestUsersCrud(t *testing.T) {
 	r, _ := http.NewRequest("GET", "https://idp.example.com/users/", nil)
 	test.Server.ServeHTTP(w, r)
 	assert.Check(t, is.Equal(http.StatusOK, w.Code))
-	assert.Check(t, is.Equal("{\"users\":[]}\n", string(w.Body.Bytes())))
+	assert.Check(t, is.Equal("{\"users\":[]}\n", w.Body.String()))
 
 	w = httptest.NewRecorder()
 	r, _ = http.NewRequest("PUT", "https://idp.example.com/users/alice",
@@ -28,13 +28,13 @@ func TestUsersCrud(t *testing.T) {
 	r, _ = http.NewRequest("GET", "https://idp.example.com/users/alice", nil)
 	test.Server.ServeHTTP(w, r)
 	assert.Check(t, is.Equal(http.StatusOK, w.Code))
-	assert.Check(t, is.Equal("{\"name\":\"alice\"}\n", string(w.Body.Bytes())))
+	assert.Check(t, is.Equal("{\"name\":\"alice\"}\n", w.Body.String()))
 
 	w = httptest.NewRecorder()
 	r, _ = http.NewRequest("GET", "https://idp.example.com/users/", nil)
 	test.Server.ServeHTTP(w, r)
 	assert.Check(t, is.Equal(http.StatusOK, w.Code))
-	assert.Check(t, is.Equal("{\"users\":[\"alice\"]}\n", string(w.Body.Bytes())))
+	assert.Check(t, is.Equal("{\"users\":[\"alice\"]}\n", w.Body.String()))
 
 	w = httptest.NewRecorder()
 	r, _ = http.NewRequest("DELETE", "https://idp.example.com/users/alice", nil)
@@ -45,5 +45,5 @@ func TestUsersCrud(t *testing.T) {
 	r, _ = http.NewRequest("GET", "https://idp.example.com/users/", nil)
 	test.Server.ServeHTTP(w, r)
 	assert.Check(t, is.Equal(http.StatusOK, w.Code))
-	assert.Check(t, is.Equal("{\"users\":[]}\n", string(w.Body.Bytes())))
+	assert.Check(t, is.Equal("{\"users\":[]}\n", w.Body.String()))
 }

--- a/samlsp/error.go
+++ b/samlsp/error.go
@@ -14,7 +14,7 @@ type ErrorFunction func(w http.ResponseWriter, r *http.Request, err error)
 // DefaultOnError is the default ErrorFunction implementation. It prints
 // an message via the standard log package and returns a simple text
 // "Forbidden" message to the user.
-func DefaultOnError(w http.ResponseWriter, r *http.Request, err error) {
+func DefaultOnError(w http.ResponseWriter, _ *http.Request, err error) {
 	if parseErr, ok := err.(*saml.InvalidResponseError); ok {
 		log.Printf("WARNING: received invalid saml response: %s (now: %s) %s",
 			parseErr.Response, parseErr.Now, parseErr.PrivateErr)

--- a/samlsp/fetch_metadata.go
+++ b/samlsp/fetch_metadata.go
@@ -12,6 +12,8 @@ import (
 	"github.com/crewjam/httperr"
 	xrv "github.com/mattermost/xml-roundtrip-validator"
 
+	"github.com/crewjam/saml/logger"
+
 	"github.com/crewjam/saml"
 )
 
@@ -61,7 +63,11 @@ func FetchMetadata(ctx context.Context, httpClient *http.Client, metadataURL url
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			logger.DefaultLogger.Printf("Error while closing response body during fetch metadata: %v", err)
+		}
+	}()
 	if resp.StatusCode >= 400 {
 		return nil, httperr.Response(*resp)
 	}

--- a/samlsp/fetch_metadata_go117_test.go
+++ b/samlsp/fetch_metadata_go117_test.go
@@ -18,12 +18,13 @@ import (
 
 func TestFetchMetadataRejectsInvalid(t *testing.T) {
 	test := NewMiddlewareTest(t)
-	test.IDPMetadata = bytes.Replace(test.IDPMetadata,
-		[]byte("<EntityDescriptor "), []byte("<EntityDescriptor ::foo=\"bar\">]]"), -1)
+	test.IDPMetadata = bytes.ReplaceAll(test.IDPMetadata,
+		[]byte("<EntityDescriptor "), []byte("<EntityDescriptor ::foo=\"bar\">]]"))
 
 	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Check(t, is.Equal("/metadata", r.URL.String()))
-		w.Write(test.IDPMetadata)
+		_, err := w.Write(test.IDPMetadata)
+		assert.Check(t, err)
 	}))
 
 	fmt.Println(testServer.URL + "/metadata")

--- a/samlsp/fetch_metadata_test.go
+++ b/samlsp/fetch_metadata_test.go
@@ -17,7 +17,8 @@ func TestFetchMetadata(t *testing.T) {
 
 	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Check(t, is.Equal("/metadata", r.URL.String()))
-		w.Write(test.IDPMetadata)
+		_, err := w.Write(test.IDPMetadata)
+		assert.Check(t, err)
 	}))
 
 	fmt.Println(testServer.URL + "/metadata")

--- a/samlsp/middleware.go
+++ b/samlsp/middleware.go
@@ -1,6 +1,7 @@
 package samlsp
 
 import (
+	"bytes"
 	"encoding/xml"
 	"net/http"
 
@@ -65,16 +66,22 @@ func (m *Middleware) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 // ServeMetadata handles requests for the SAML metadata endpoint.
-func (m *Middleware) ServeMetadata(w http.ResponseWriter, r *http.Request) {
+func (m *Middleware) ServeMetadata(w http.ResponseWriter, _ *http.Request) {
 	buf, _ := xml.MarshalIndent(m.ServiceProvider.Metadata(), "", "  ")
 	w.Header().Set("Content-Type", "application/samlmetadata+xml")
-	w.Write(buf)
-	return
+	if _, err := w.Write(buf); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
 }
 
 // ServeACS handles requests for the SAML ACS endpoint.
 func (m *Middleware) ServeACS(w http.ResponseWriter, r *http.Request) {
-	r.ParseForm()
+	err := r.ParseForm()
+	if err != nil {
+		m.OnError(w, r, err)
+		return
+	}
 
 	possibleRequestIDs := []string{}
 	if m.ServiceProvider.AllowIDPInitiated {
@@ -93,7 +100,6 @@ func (m *Middleware) ServeACS(w http.ResponseWriter, r *http.Request) {
 	}
 
 	m.CreateSessionFromAssertion(w, r, assertion, m.ServiceProvider.DefaultRedirectURI)
-	return
 }
 
 // RequireAccount is HTTP middleware that requires that each request be
@@ -114,7 +120,6 @@ func (m *Middleware) RequireAccount(handler http.Handler) http.Handler {
 		}
 
 		m.OnError(w, r, err)
-		return
 	})
 }
 
@@ -173,9 +178,14 @@ func (m *Middleware) HandleStartAuthFlow(w http.ResponseWriter, r *http.Request)
 			"script-src 'sha256-AjPdJSbZmeWHnEc5ykvJFay8FTWeTeRbs9dutfZ0HqE='; "+
 			"reflected-xss block; referrer no-referrer;")
 		w.Header().Add("Content-type", "text/html")
-		w.Write([]byte(`<!DOCTYPE html><html><body>`))
-		w.Write(authReq.Post(relayState))
-		w.Write([]byte(`</body></html>`))
+		var buf bytes.Buffer
+		buf.WriteString(`<!DOCTYPE html><html><body>`)
+		buf.Write(authReq.Post(relayState))
+		buf.WriteString(`</body></html>`)
+		if _, err := w.Write(buf.Bytes()); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
 		return
 	}
 	panic("not reached")
@@ -195,7 +205,10 @@ func (m *Middleware) CreateSessionFromAssertion(w http.ResponseWriter, r *http.R
 				return
 			}
 		} else {
-			m.RequestTracker.StopTrackingRequest(w, r, trackedRequestIndex)
+			if err := m.RequestTracker.StopTrackingRequest(w, r, trackedRequestIndex); err != nil {
+				m.OnError(w, r, err)
+				return
+			}
 
 			redirectURI = trackedRequest.URI
 		}

--- a/samlsp/middleware_test.go
+++ b/samlsp/middleware_test.go
@@ -426,7 +426,7 @@ func TestMiddlewareDefaultCookieDomainIPv4(t *testing.T) {
 
 	req, _ := http.NewRequest("GET", "/", nil)
 	resp := httptest.NewRecorder()
-	sp.CreateSession(resp, req, &saml.Assertion{})
+	assert.Check(t, sp.CreateSession(resp, req, &saml.Assertion{}))
 
 	assert.Check(t,
 		strings.Contains(resp.Header().Get("Set-Cookie"), "Domain=127.0.0.1;"),
@@ -445,7 +445,7 @@ func TestMiddlewareDefaultCookieDomainIPv6(t *testing.T) {
 
 	req, _ := http.NewRequest("GET", "/", nil)
 	resp := httptest.NewRecorder()
-	sp.CreateSession(resp, req, &saml.Assertion{})
+	assert.Check(t, sp.CreateSession(resp, req, &saml.Assertion{}))
 
 	assert.Check(t,
 		strings.Contains(resp.Header().Get("Set-Cookie"), "Domain=::1;"),

--- a/samlsp/session_cookie_test.go
+++ b/samlsp/session_cookie_test.go
@@ -26,10 +26,12 @@ func TestCookieSameSite(t *testing.T) {
 		resp := httptest.NewRecorder()
 		req := httptest.NewRequest(http.MethodGet, "/", nil)
 		err := csp.CreateSession(resp, req, &saml.Assertion{})
-		assert.Check(t, err)
+		assert.Check(tb, err)
 
-		cookies := resp.Result().Cookies()
-		assert.Check(t, is.Len(cookies, 1), "Expected to have a cookie set")
+		result := resp.Result()
+		cookies := result.Cookies()
+		assert.Check(tb, is.Len(cookies, 1), "Expected to have a cookie set")
+		assert.Check(tb, result.Body.Close())
 
 		return cookies[0]
 	}

--- a/samlsp/session_jwt.go
+++ b/samlsp/session_jwt.go
@@ -106,7 +106,7 @@ func (c JWTSessionCodec) Decode(signed string) (Session, error) {
 	if !claims.VerifyIssuer(c.Issuer, true) {
 		return nil, fmt.Errorf("expected issuer %q, got %q", c.Issuer, claims.Issuer)
 	}
-	if claims.SAMLSession != true {
+	if !claims.SAMLSession {
 		return nil, errors.New("expected saml-session")
 	}
 	return claims, nil

--- a/schema.go
+++ b/schema.go
@@ -48,7 +48,7 @@ type AuthnRequest struct {
 	NameIDPolicy          *NameIDPolicy `xml:"urn:oasis:names:tc:SAML:2.0:protocol NameIDPolicy"`
 	Conditions            *Conditions
 	RequestedAuthnContext *RequestedAuthnContext
-	//Scoping               *Scoping // TODO
+	// Scoping               *Scoping // TODO
 
 	ForceAuthn                     *bool  `xml:",attr"`
 	IsPassive                      *bool  `xml:",attr"`
@@ -108,7 +108,7 @@ func (r *LogoutRequest) Element() *etree.Element {
 }
 
 // MarshalXML implements xml.Marshaler
-func (r *LogoutRequest) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+func (r *LogoutRequest) MarshalXML(e *xml.Encoder, _ xml.StartElement) error {
 	type Alias LogoutRequest
 	aux := &struct {
 		IssueInstant RelaxedTime  `xml:",attr"`
@@ -209,9 +209,9 @@ func (r *AuthnRequest) Element() *etree.Element {
 	if r.RequestedAuthnContext != nil {
 		el.AddChild(r.RequestedAuthnContext.Element())
 	}
-	//if r.Scoping != nil {
-	//	el.AddChild(r.Scoping.Element())
-	//}
+	// if r.Scoping != nil {
+	// 	el.AddChild(r.Scoping.Element())
+	// }
 	if r.ForceAuthn != nil {
 		el.CreateAttr("ForceAuthn", strconv.FormatBool(*r.ForceAuthn))
 	}
@@ -237,7 +237,7 @@ func (r *AuthnRequest) Element() *etree.Element {
 }
 
 // MarshalXML implements xml.Marshaler
-func (r *AuthnRequest) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+func (r *AuthnRequest) MarshalXML(e *xml.Encoder, _ xml.StartElement) error {
 	type Alias AuthnRequest
 	aux := &struct {
 		IssueInstant RelaxedTime `xml:",attr"`
@@ -374,7 +374,7 @@ func (r *ArtifactResolve) SoapRequest() *etree.Element {
 }
 
 // MarshalXML implements xml.Marshaler
-func (r *ArtifactResolve) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+func (r *ArtifactResolve) MarshalXML(e *xml.Encoder, _ xml.StartElement) error {
 	type Alias ArtifactResolve
 	aux := &struct {
 		IssueInstant RelaxedTime `xml:",attr"`
@@ -448,7 +448,7 @@ func (r *ArtifactResponse) Element() *etree.Element {
 }
 
 // MarshalXML implements xml.Marshaler
-func (r *ArtifactResponse) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+func (r *ArtifactResponse) MarshalXML(e *xml.Encoder, _ xml.StartElement) error {
 	type Alias ArtifactResponse
 	aux := &struct {
 		IssueInstant RelaxedTime `xml:",attr"`
@@ -542,7 +542,7 @@ func (r *Response) Element() *etree.Element {
 }
 
 // MarshalXML implements xml.Marshaler
-func (r *Response) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+func (r *Response) MarshalXML(e *xml.Encoder, _ xml.StartElement) error {
 	type Alias Response
 	aux := &struct {
 		IssueInstant RelaxedTime `xml:",attr"`
@@ -1153,9 +1153,9 @@ func (a *SubjectLocality) Element() *etree.Element {
 // See http://docs.oasis-open.org/security/saml/v2.0/saml-core-2.0-os.pdf §2.7.2.2
 type AuthnContext struct {
 	AuthnContextClassRef *AuthnContextClassRef
-	//AuthnContextDecl          *AuthnContextDecl        ... TODO
-	//AuthnContextDeclRef       *AuthnContextDeclRef     ... TODO
-	//AuthenticatingAuthorities []AuthenticatingAuthority... TODO
+	// AuthnContextDecl          *AuthnContextDecl        ... TODO
+	// AuthnContextDeclRef       *AuthnContextDeclRef     ... TODO
+	// AuthenticatingAuthorities []AuthenticatingAuthority... TODO
 }
 
 // Element returns an etree.Element representing the object in XML form.
@@ -1292,7 +1292,7 @@ func (r *LogoutResponse) Element() *etree.Element {
 }
 
 // MarshalXML implements xml.Marshaler
-func (r *LogoutResponse) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+func (r *LogoutResponse) MarshalXML(e *xml.Encoder, _ xml.StartElement) error {
 	type Alias LogoutResponse
 	aux := &struct {
 		IssueInstant RelaxedTime `xml:",attr"`

--- a/service_provider.go
+++ b/service_provider.go
@@ -23,6 +23,7 @@ import (
 	dsig "github.com/russellhaering/goxmldsig"
 	"github.com/russellhaering/goxmldsig/etreeutils"
 
+	"github.com/crewjam/saml/logger"
 	"github.com/crewjam/saml/xmlenc"
 )
 
@@ -189,13 +190,13 @@ func (sp *ServiceProvider) Metadata() *EntityDescriptor {
 		}
 	}
 
-	var sloEndpoints []Endpoint
-	for _, binding := range sp.LogoutBindings {
-		sloEndpoints = append(sloEndpoints, Endpoint{
+	sloEndpoints := make([]Endpoint, len(sp.LogoutBindings))
+	for i, binding := range sp.LogoutBindings {
+		sloEndpoints[i] = Endpoint{
 			Binding:          binding,
 			Location:         sp.SloURL.String(),
 			ResponseLocation: sp.SloURL.String(),
-		})
+		}
 	}
 
 	return &EntityDescriptor{
@@ -245,25 +246,29 @@ func (sp *ServiceProvider) MakeRedirectAuthenticationRequest(relayState string) 
 }
 
 // Redirect returns a URL suitable for using the redirect binding with the request
-func (req *AuthnRequest) Redirect(relayState string, sp *ServiceProvider) (*url.URL, error) {
+func (r *AuthnRequest) Redirect(relayState string, sp *ServiceProvider) (*url.URL, error) {
 	w := &bytes.Buffer{}
 	w1 := base64.NewEncoder(base64.StdEncoding, w)
 	w2, _ := flate.NewWriter(w1, 9)
 	doc := etree.NewDocument()
-	doc.SetRoot(req.Element())
+	doc.SetRoot(r.Element())
 	if _, err := doc.WriteTo(w2); err != nil {
 		panic(err)
 	}
-	w2.Close()
-	w1.Close()
+	if err := w2.Close(); err != nil {
+		panic(err)
+	}
+	if err := w1.Close(); err != nil {
+		panic(err)
+	}
 
-	rv, _ := url.Parse(req.Destination)
+	rv, _ := url.Parse(r.Destination)
 	// We can't depend on Query().set() as order matters for signing
 	query := rv.RawQuery
 	if len(query) > 0 {
-		query += "&SAMLRequest=" + url.QueryEscape(string(w.Bytes()))
+		query += "&SAMLRequest=" + url.QueryEscape(w.String())
 	} else {
-		query += "SAMLRequest=" + url.QueryEscape(string(w.Bytes()))
+		query += "SAMLRequest=" + url.QueryEscape(w.String())
 	}
 
 	if relayState != "" {
@@ -352,11 +357,11 @@ func (sp *ServiceProvider) getIDPSigningCerts() ([]*x509.Certificate, error) {
 		return nil, errors.New("cannot find any signing certificate in the IDP SSO descriptor")
 	}
 
-	var certs []*x509.Certificate
+	certs := make([]*x509.Certificate, len(certStrs))
 
 	// cleanup whitespace
 	regex := regexp.MustCompile(`\s+`)
-	for _, certStr := range certStrs {
+	for i, certStr := range certStrs {
 		certStr = regex.ReplaceAllString(certStr, "")
 		certBytes, err := base64.StdEncoding.DecodeString(certStr)
 		if err != nil {
@@ -367,7 +372,7 @@ func (sp *ServiceProvider) getIDPSigningCerts() ([]*x509.Certificate, error) {
 		if err != nil {
 			return nil, err
 		}
-		certs = append(certs, parsedCert)
+		certs[i] = parsedCert
 	}
 
 	return certs, nil
@@ -439,9 +444,9 @@ func GetSigningContext(sp *ServiceProvider) (*dsig.SigningContext, error) {
 		Leaf:        sp.Certificate,
 	}
 	// TODO: add intermediates for SP
-	//for _, cert := range sp.Intermediates {
-	//	keyPair.Certificate = append(keyPair.Certificate, cert.Raw)
-	//}
+	// for _, cert := range sp.Intermediates {
+	// 	keyPair.Certificate = append(keyPair.Certificate, cert.Raw)
+	// }
 	keyStore := dsig.TLSCertKeyStore(keyPair)
 
 	if sp.SignatureMethod != dsig.RSASHA1SignatureMethod &&
@@ -508,9 +513,9 @@ func (sp *ServiceProvider) MakePostAuthenticationRequest(relayState string) ([]b
 }
 
 // Post returns an HTML form suitable for using the HTTP-POST binding with the request
-func (req *AuthnRequest) Post(relayState string) []byte {
+func (r *AuthnRequest) Post(relayState string) []byte {
 	doc := etree.NewDocument()
-	doc.SetRoot(req.Element())
+	doc.SetRoot(r.Element())
 	reqBuf, err := doc.WriteToBytes()
 	if err != nil {
 		panic(err)
@@ -530,7 +535,7 @@ func (req *AuthnRequest) Post(relayState string) []byte {
 		SAMLRequest string
 		RelayState  string
 	}{
-		URL:         req.Destination,
+		URL:         r.Destination,
 		SAMLRequest: encodedReqBuf,
 		RelayState:  relayState,
 	}
@@ -579,7 +584,7 @@ type InvalidResponseError struct {
 }
 
 func (ivr *InvalidResponseError) Error() string {
-	return fmt.Sprintf("Authentication failed")
+	return "Authentication failed"
 }
 
 // ErrBadStatus is returned when the assertion provided is valid but the
@@ -606,7 +611,7 @@ func (sp *ServiceProvider) handleArtifactRequest(ctx context.Context, artifactID
 
 	artifactResolveRequest, err := sp.MakeArtifactResolveRequest(artifactID)
 	if err != nil {
-		retErr.PrivateErr = fmt.Errorf("Cannot generate artifact resolution request: %s", err)
+		retErr.PrivateErr = fmt.Errorf("cannot generate artifact resolution request: %s", err)
 		return nil, retErr
 	}
 
@@ -633,7 +638,11 @@ func (sp *ServiceProvider) handleArtifactRequest(ctx context.Context, artifactID
 		retErr.PrivateErr = fmt.Errorf("cannot resolve artifact: %s", err)
 		return nil, retErr
 	}
-	defer response.Body.Close()
+	defer func() {
+		if err := response.Body.Close(); err != nil {
+			logger.DefaultLogger.Printf("Error while closing response body during artifact resolution: %v", err)
+		}
+	}()
 	if response.StatusCode != 200 {
 		retErr.PrivateErr = fmt.Errorf("Error during artifact resolution: HTTP status %d (%s)", response.StatusCode, response.Status)
 		return nil, retErr
@@ -753,11 +762,12 @@ func (sp *ServiceProvider) parseArtifactResponse(artifactResponseEl *etree.Eleme
 
 	var signatureRequirement signatureRequirement
 	sigErr := sp.validateSignature(artifactResponseEl)
-	if sigErr == nil {
+	switch sigErr {
+	case nil:
 		signatureRequirement = signatureNotRequired
-	} else if sigErr == errSignatureElementNotPresent {
+	case errSignatureElementNotPresent:
 		signatureRequirement = signatureRequired
-	} else {
+	default:
 		retErr.PrivateErr = sigErr
 		return nil, retErr
 	}
@@ -888,13 +898,14 @@ func (sp *ServiceProvider) parseResponse(responseEl *etree.Element, possibleRequ
 	}
 
 	if signatureRequirement == signatureRequired {
-		if responseSignatureErr == nil {
+		switch responseSignatureErr {
+		case nil:
 			// since the request has a signature, none of the Assertions need one
 			signatureRequirement = signatureNotRequired
-		} else if responseSignatureErr == errSignatureElementNotPresent {
+		case errSignatureElementNotPresent:
 			// the request has no signature, so assertions must be signed
 			signatureRequirement = signatureRequired // nop
-		} else {
+		default:
 			return nil, responseSignatureErr
 		}
 	}
@@ -1078,7 +1089,7 @@ func (sp *ServiceProvider) validateAssertion(assertion *Assertion, possibleReque
 	return nil
 }
 
-var errSignatureElementNotPresent = errors.New("Signature element not present")
+var errSignatureElementNotPresent = errors.New("signature element not present")
 
 // validateSignature returns nil iff the Signature embedded in the element is valid
 func (sp *ServiceProvider) validateSignature(el *etree.Element) error {
@@ -1154,9 +1165,9 @@ func (sp *ServiceProvider) SignLogoutRequest(req *LogoutRequest) error {
 		Leaf:        sp.Certificate,
 	}
 	// TODO: add intermediates for SP
-	//for _, cert := range sp.Intermediates {
-	//	keyPair.Certificate = append(keyPair.Certificate, cert.Raw)
-	//}
+	// for _, cert := range sp.Intermediates {
+	// 	keyPair.Certificate = append(keyPair.Certificate, cert.Raw)
+	// }
 	keyStore := dsig.TLSCertKeyStore(keyPair)
 
 	if sp.SignatureMethod != dsig.RSASHA1SignatureMethod &&
@@ -1222,22 +1233,26 @@ func (sp *ServiceProvider) MakeRedirectLogoutRequest(nameID, relayState string) 
 }
 
 // Redirect returns a URL suitable for using the redirect binding with the request
-func (req *LogoutRequest) Redirect(relayState string) *url.URL {
+func (r *LogoutRequest) Redirect(relayState string) *url.URL {
 	w := &bytes.Buffer{}
 	w1 := base64.NewEncoder(base64.StdEncoding, w)
 	w2, _ := flate.NewWriter(w1, 9)
 	doc := etree.NewDocument()
-	doc.SetRoot(req.Element())
+	doc.SetRoot(r.Element())
 	if _, err := doc.WriteTo(w2); err != nil {
 		panic(err)
 	}
-	w2.Close()
-	w1.Close()
+	if err := w2.Close(); err != nil {
+		panic(err)
+	}
+	if err := w1.Close(); err != nil {
+		panic(err)
+	}
 
-	rv, _ := url.Parse(req.Destination)
+	rv, _ := url.Parse(r.Destination)
 
 	query := rv.Query()
-	query.Set("SAMLRequest", string(w.Bytes()))
+	query.Set("SAMLRequest", w.String())
 	if relayState != "" {
 		query.Set("RelayState", relayState)
 	}
@@ -1258,9 +1273,9 @@ func (sp *ServiceProvider) MakePostLogoutRequest(nameID, relayState string) ([]b
 }
 
 // Post returns an HTML form suitable for using the HTTP-POST binding with the request
-func (req *LogoutRequest) Post(relayState string) []byte {
+func (r *LogoutRequest) Post(relayState string) []byte {
 	doc := etree.NewDocument()
-	doc.SetRoot(req.Element())
+	doc.SetRoot(r.Element())
 	reqBuf, err := doc.WriteToBytes()
 	if err != nil {
 		panic(err)
@@ -1280,7 +1295,7 @@ func (req *LogoutRequest) Post(relayState string) []byte {
 		SAMLRequest string
 		RelayState  string
 	}{
-		URL:         req.Destination,
+		URL:         r.Destination,
 		SAMLRequest: encodedReqBuf,
 		RelayState:  relayState,
 	}
@@ -1332,22 +1347,26 @@ func (sp *ServiceProvider) MakeRedirectLogoutResponse(logoutRequestID, relayStat
 }
 
 // Redirect returns a URL suitable for using the redirect binding with the LogoutResponse.
-func (resp *LogoutResponse) Redirect(relayState string) *url.URL {
+func (r *LogoutResponse) Redirect(relayState string) *url.URL {
 	w := &bytes.Buffer{}
 	w1 := base64.NewEncoder(base64.StdEncoding, w)
 	w2, _ := flate.NewWriter(w1, 9)
 	doc := etree.NewDocument()
-	doc.SetRoot(resp.Element())
+	doc.SetRoot(r.Element())
 	if _, err := doc.WriteTo(w2); err != nil {
 		panic(err)
 	}
-	w2.Close()
-	w1.Close()
+	if err := w2.Close(); err != nil {
+		panic(err)
+	}
+	if err := w1.Close(); err != nil {
+		panic(err)
+	}
 
-	rv, _ := url.Parse(resp.Destination)
+	rv, _ := url.Parse(r.Destination)
 
 	query := rv.Query()
-	query.Set("SAMLResponse", string(w.Bytes()))
+	query.Set("SAMLResponse", w.String())
 	if relayState != "" {
 		query.Set("RelayState", relayState)
 	}
@@ -1368,9 +1387,9 @@ func (sp *ServiceProvider) MakePostLogoutResponse(logoutRequestID, relayState st
 }
 
 // Post returns an HTML form suitable for using the HTTP-POST binding with the LogoutResponse.
-func (resp *LogoutResponse) Post(relayState string) []byte {
+func (r *LogoutResponse) Post(relayState string) []byte {
 	doc := etree.NewDocument()
-	doc.SetRoot(resp.Element())
+	doc.SetRoot(r.Element())
 	reqBuf, err := doc.WriteToBytes()
 	if err != nil {
 		panic(err)
@@ -1390,7 +1409,7 @@ func (resp *LogoutResponse) Post(relayState string) []byte {
 		SAMLResponse string
 		RelayState   string
 	}{
-		URL:          resp.Destination,
+		URL:          r.Destination,
 		SAMLResponse: encodedReqBuf,
 		RelayState:   relayState,
 	}
@@ -1411,9 +1430,9 @@ func (sp *ServiceProvider) SignLogoutResponse(resp *LogoutResponse) error {
 		Leaf:        sp.Certificate,
 	}
 	// TODO: add intermediates for SP
-	//for _, cert := range sp.Intermediates {
-	//	keyPair.Certificate = append(keyPair.Certificate, cert.Raw)
-	//}
+	// for _, cert := range sp.Intermediates {
+	// 	keyPair.Certificate = append(keyPair.Certificate, cert.Raw)
+	// }
 	keyStore := dsig.TLSCertKeyStore(keyPair)
 
 	if sp.SignatureMethod != dsig.RSASHA1SignatureMethod &&
@@ -1502,10 +1521,7 @@ func (sp *ServiceProvider) ValidateLogoutResponseForm(postFormData string) error
 		retErr.PrivateErr = err
 		return retErr
 	}
-	if err := sp.validateLogoutResponse(&resp); err != nil {
-		return err
-	}
-	return nil
+	return sp.validateLogoutResponse(&resp)
 }
 
 // ValidateLogoutResponseRedirect returns a nil error if the logout response is valid.
@@ -1550,10 +1566,7 @@ func (sp *ServiceProvider) ValidateLogoutResponseRedirect(queryParameterData str
 		retErr.PrivateErr = err
 		return retErr
 	}
-	if err := sp.validateLogoutResponse(&resp); err != nil {
-		return err
-	}
-	return nil
+	return sp.validateLogoutResponse(&resp)
 }
 
 // validateLogoutResponse validates the LogoutResponse fields. Returns a nil error if the LogoutResponse is valid.
@@ -1585,6 +1598,7 @@ func firstSet(a, b string) string {
 
 // findChildren returns all the elements matching childNS/childTag that are direct children of parentEl.
 func findChildren(parentEl *etree.Element, childNS string, childTag string) ([]*etree.Element, error) {
+	//nolint:prealloc // We don't know how many child elements we'll actually put into this array.
 	var rv []*etree.Element
 	for _, childEl := range parentEl.ChildElements() {
 		if childEl.Tag != childTag {

--- a/testsaml/parse.go
+++ b/testsaml/parse.go
@@ -1,3 +1,4 @@
+// Package testsaml contains functions for use in testing SAML requests and responses.
 package testsaml
 
 import (

--- a/util.go
+++ b/util.go
@@ -21,6 +21,7 @@ var Clock *dsig.Clock
 // rand.Reader, but it can be replaced for testing.
 var RandReader = rand.Reader
 
+//nolint:unparam // This always receives 20, but we want the option to do more or less if needed.
 func randomBytes(n int) []byte {
 	rv := make([]byte, n)
 

--- a/xmlenc/cbc.go
+++ b/xmlenc/cbc.go
@@ -31,7 +31,7 @@ func (e CBC) Algorithm() string {
 
 // Encrypt encrypts plaintext with key, which should be a []byte of length KeySize().
 // It returns an xenc:EncryptedData element.
-func (e CBC) Encrypt(key interface{}, plaintext []byte, nonce []byte) (*etree.Element, error) {
+func (e CBC) Encrypt(key interface{}, plaintext []byte, _ []byte) (*etree.Element, error) {
 	keyBuf, ok := key.([]byte)
 	if !ok {
 		return nil, ErrIncorrectKeyType("[]byte")

--- a/xmlenc/decrypt.go
+++ b/xmlenc/decrypt.go
@@ -90,6 +90,7 @@ func validateRSAKeyIfPresent(key interface{}, encryptedKey *etree.Element) (*rsa
 	// if the key will work, or let the service provider know which key
 	// to use to decrypt the message. Either way, verification is not
 	// security-critical.
+	//nolint:revive,staticcheck // Keep the later empty branch so that we know to address this at a later date.
 	if el := encryptedKey.FindElement("./KeyInfo/X509Data/X509Certificate"); el != nil {
 		certPEMbuf := el.Text()
 		certPEMbuf = "-----BEGIN CERTIFICATE-----\n" + certPEMbuf + "\n-----END CERTIFICATE-----\n"

--- a/xmlenc/decrypt_test.go
+++ b/xmlenc/decrypt_test.go
@@ -100,6 +100,5 @@ func TestCanDecryptWithoutCertificate(t *testing.T) {
 		el = doc.Root().FindElement("//EncryptedData")
 		_, err = Decrypt(key, el)
 		assert.Check(t, err)
-		//assertion.NotNil(t, plaintext)
 	})
 }

--- a/xmlenc/digest.go
+++ b/xmlenc/digest.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha512"
 	"hash"
 
+	//nolint:staticcheck // We should support this for legacy reasons.
 	"golang.org/x/crypto/ripemd160"
 )
 


### PR DESCRIPTION
golangci-lint has been updated as the error currently being seen in CI appears to be resolved in 1.5x per the discussion in https://github.com/golangci/golangci-lint/issues/3107. Linting fixes have been applied and several of the disabled linters have been enabled.