### PR TITLE
Fix logger and service providers fields initialization

### DIFF
--- a/samlidp/samlidp.go
+++ b/samlidp/samlidp.go
@@ -80,6 +80,9 @@ func New(opts Options) (*Server, error) {
 	return s, nil
 }
 
+// Initialize the Server logger. (This function should be used only when
+// not using the default New(opts Options) function where the logger
+// object can be passed through the options)
 func (s *Server) InitializeLogger(logger logger.Interface) {
 	if s != nil {
 		s.logger = logger

--- a/samlidp/samlidp.go
+++ b/samlidp/samlidp.go
@@ -80,6 +80,12 @@ func New(opts Options) (*Server, error) {
 	return s, nil
 }
 
+func (s *Server) InitializeLogger(logger logger.Interface) {
+	if s != nil {
+		s.logger = logger
+	}
+}
+
 // InitializeHTTP sets up the HTTP handler for the server. (This function
 // is called automatically for you by New, but you may need to call it
 // yourself if you don't create the object using New.)

--- a/samlidp/samlidp.go
+++ b/samlidp/samlidp.go
@@ -80,7 +80,7 @@ func New(opts Options) (*Server, error) {
 	return s, nil
 }
 
-// Initialize the Server logger. (This function should be used only when
+// InitializeLogger initialize the Server logger. (This function should be used only when
 // not using the default New(opts Options) function where the logger
 // object can be passed through the options)
 func (s *Server) InitializeLogger(logger logger.Interface) {

--- a/samlidp/service.go
+++ b/samlidp/service.go
@@ -93,6 +93,9 @@ func (s *Server) HandlePutService(c web.C, w http.ResponseWriter, r *http.Reques
 	}
 
 	s.idpConfigMu.Lock()
+	if s.serviceProviders == nil {
+		s.serviceProviders = map[string]*saml.EntityDescriptor{}
+	}
 	s.serviceProviders[service.Metadata.EntityID] = &service.Metadata
 	s.idpConfigMu.Unlock()
 


### PR DESCRIPTION
The `logger` and `serviceProviders` fields of `samlidp.Server` object are not exported and therefor cannot be initialized when not using the default `func New(opts Options) (*Server, error)` ,
The fix include two things:
1. Added InitializeLogger(..) function so logger can be initialized
2. Added check for nil map before adding new serviceProvider which will initialized the map if needed. 