### PR TITLE
Add support for POST on a wrapped request

### DIFF
--- a/samlsp/middleware_test.go
+++ b/samlsp/middleware_test.go
@@ -115,6 +115,7 @@ func (test *MiddlewareTest) makeTrackedRequest(id string) string {
 		Index:         "KCosLjAyNDY4Ojw-QEJERkhKTE5QUlRWWFpcXmBiZGZoamxucHJ0dnh6",
 		SAMLRequestID: id,
 		URI:           "/frob",
+		Method:        "GET",
 	})
 	if err != nil {
 		panic(err)

--- a/samlsp/request_tracker.go
+++ b/samlsp/request_tracker.go
@@ -2,6 +2,7 @@ package samlsp
 
 import (
 	"net/http"
+	"net/url"
 )
 
 // RequestTracker tracks pending authentication requests.
@@ -31,9 +32,11 @@ type RequestTracker interface {
 
 // TrackedRequest holds the data we store for each pending request.
 type TrackedRequest struct {
-	Index         string `json:"-"`
-	SAMLRequestID string `json:"id"`
-	URI           string `json:"uri"`
+	Index         string     `json:"-"`
+	SAMLRequestID string     `json:"id"`
+	URI           string     `json:"uri"`
+	Method        string     `json:"method"`
+	PostData      url.Values `json:"post_data"`
 }
 
 // TrackedRequestCodec handles encoding and decoding of a TrackedRequest.

--- a/samlsp/request_tracker_cookie.go
+++ b/samlsp/request_tracker_cookie.go
@@ -26,10 +26,15 @@ type CookieRequestTracker struct {
 // TrackRequest starts tracking the SAML request with the given ID. It returns an
 // `index` that should be used as the RelayState in the SAMl request flow.
 func (t CookieRequestTracker) TrackRequest(w http.ResponseWriter, r *http.Request, samlRequestID string) (string, error) {
+	if r.Method == "POST" {
+		r.ParseForm()
+	}
 	trackedRequest := TrackedRequest{
 		Index:         base64.RawURLEncoding.EncodeToString(randomBytes(42)),
 		SAMLRequestID: samlRequestID,
 		URI:           r.URL.String(),
+		Method:        r.Method,
+		PostData:      r.PostForm,
 	}
 
 	if t.RelayStateFunc != nil {


### PR DESCRIPTION
When a request is made to an endpoint with the method set to POST, if the user has no session currently, we start the SAML authentication flow. When the assertion comes back, we will then redirect to the URL where the POST request was made, which will do a GET to that URL with no body. This obviously breaks the original POST.

This PR adds storage of the method and post form storage to `TrackedRequest `, and once we are done with the SAML Assertion, if the original request was a POST, we use the same method that `IdpAuthnRequest` uses in `WriteResponse` to create a form that uses a tiny bit of javascript to POST back to the original endpoint.

Obviously this won't work for large forms, since the `TrackedRequest` will then generate a cookie which is too big, but it's better than making a GET to an endpoint expecting a POST.