### PR TITLE
SLO reads wrong buffer when unmarshalling

### DIFF
--- a/service_provider.go
+++ b/service_provider.go
@@ -1551,7 +1551,7 @@ func (sp *ServiceProvider) ValidateLogoutResponseRedirect(queryParameterData str
 	}
 
 	doc := etree.NewDocument()
-	if err := doc.ReadFromBytes(rawResponseBuf); err != nil {
+	if err := doc.ReadFromBytes(gr); err != nil {
 		retErr.PrivateErr = err
 		return retErr
 	}


### PR DESCRIPTION
Found this issue while implementing an SP and working on the logout flow