### PR TITLE
fix login form being submitted to /sso instead of /login

### DIFF
--- a/identity_provider.go
+++ b/identity_provider.go
@@ -101,6 +101,7 @@ type IdentityProvider struct {
 	Intermediates           []*x509.Certificate
 	MetadataURL             url.URL
 	SSOURL                  url.URL
+	LoginURL                url.URL
 	LogoutURL               url.URL
 	ServiceProviderProvider ServiceProviderProvider
 	SessionProvider         SessionProvider

--- a/samlidp/samlidp.go
+++ b/samlidp/samlidp.go
@@ -51,6 +51,8 @@ func New(opts Options) (*Server, error) {
 	metadataURL.Path += "/metadata"
 	ssoURL := opts.URL
 	ssoURL.Path += "/sso"
+	loginURL := opts.URL
+	loginURL.Path += "/login"
 	logr := opts.Logger
 	if logr == nil {
 		logr = logger.DefaultLogger
@@ -65,6 +67,7 @@ func New(opts Options) (*Server, error) {
 			Certificate: opts.Certificate,
 			MetadataURL: metadataURL,
 			SSOURL:      ssoURL,
+			LoginURL:    loginURL,
 		},
 		logger: logr,
 		Store:  opts.Store,

--- a/samlidp/session.go
+++ b/samlidp/session.go
@@ -122,7 +122,7 @@ func (s *Server) sendLoginForm(w http.ResponseWriter, _ *http.Request, req *saml
 		RelayState  string
 	}{
 		Toast:       toast,
-		URL:         req.IDP.SSOURL.String(),
+		URL:         req.IDP.LoginURL.String(),
 		SAMLRequest: base64.StdEncoding.EncodeToString(req.RequestBuffer),
 		RelayState:  req.RelayState,
 	}


### PR DESCRIPTION
Tbh I'm not 100% certain about this fix, because it's been like this since the very first commit adding the login form... but I can't see how this has ever worked...

If the login form submits to `/sso` then it will hit the `req.Validate()` and it will fail with a `http.StatusBadRequest`.  
technically if it would get past that check it would then actually read the form payload, but I don't know how it ever can ...

is it possible nobody has been using the `/login` endpoint for a long time?


