### PR TITLE
fix: Improper namespace application in elementToBytes

### DIFF
--- a/service_provider.go
+++ b/service_provider.go
@@ -1672,7 +1672,11 @@ func elementToBytes(el *etree.Element) ([]byte, error) {
 	doc := etree.NewDocument()
 	doc.SetRoot(el.Copy())
 	for space, uri := range namespaces {
-		doc.Root().CreateAttr("xmlns:"+space, uri)
+		if space == "" {
+			doc.Root().CreateAttr("xmlns", uri)
+		} else {
+			doc.Root().CreateAttr("xmlns:"+space, uri)
+		}
 	}
 
 	return doc.WriteToBytes()


### PR DESCRIPTION
In the `elemToBytes` function when applying namespaces to the `doc.Root()` it is assumed that the namespace will have a prefix. If the namespace is the default namespace `xmlns` the function improperly applies the namespace as: 

`xmlns:=<URI>` - which is invalid XML. 

This can cause errors when parsing Assertions that do not have explicit namespaces applied and inherit the default namespace from their parent element. 

This PR updates the `elemToBytes` function to account for this. 

Related issues: 
https://github.com/crewjam/saml/issues/578
https://github.com/crewjam/saml/issues/527
