### PR TITLE
Added callback-based request ID checking

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/wz2b/saml
+module github.com/crewjam/saml
 
 go 1.23
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
-module github.com/crewjam/saml
+module github.com/wz2b/saml
 
-go 1.19
+go 1.23
 
 require (
 	github.com/beevik/etree v1.2.0

--- a/requestid.go
+++ b/requestid.go
@@ -1,0 +1,14 @@
+package saml
+
+type RequestIdCheckFunction func(string) bool
+
+func createDefaultChecker(possibleRequestIDs []string) RequestIdCheckFunction {
+	return func(id string) bool {
+		for _, possibleRequestID := range possibleRequestIDs {
+			if id == possibleRequestID {
+				return true
+			}
+		}
+		return false
+	}
+}

--- a/service_provider.go
+++ b/service_provider.go
@@ -1054,7 +1054,7 @@ func (sp *ServiceProvider) parseAssertion(assertionEl *etree.Element, checkFunct
 		return nil, err
 	}
 
-	if err := sp.validateAssertion(&assertion, checkFunction, now); err != nil {
+	if err := sp.validateAssertion2(&assertion, checkFunction, now); err != nil {
 		return nil, err
 	}
 
@@ -1065,7 +1065,11 @@ func (sp *ServiceProvider) parseAssertion(assertionEl *etree.Element, checkFunct
 // the requirements to accept. If validation fails, it returns an error describing
 // the failure. (The digital signature on the assertion is not checked -- this
 // should be done before calling this function).
-func (sp *ServiceProvider) validateAssertion(assertion *Assertion, checkFunction RequestIdCheckFunction, now time.Time) error {
+func (sp *ServiceProvider) validateAssertion(assertion *Assertion, allowedRequestIds []string, now time.Time) error {
+	return sp.validateAssertion2(assertion, createDefaultChecker(allowedRequestIds), now)
+}
+
+func (sp *ServiceProvider) validateAssertion2(assertion *Assertion, checkFunction RequestIdCheckFunction, now time.Time) error {
 	if assertion.IssueInstant.Add(MaxIssueDelay).Before(now) {
 		return fmt.Errorf("expired on %s", assertion.IssueInstant.Add(MaxIssueDelay))
 	}


### PR DESCRIPTION
The main purpose of this PR is to add the ability to specify authorized IDs by passing in a checking function. This allows you to do more than just check that the ID is in a list - for example you can put expirations on the ID tokens.

For backward compatibility, I left the public-facing functions the same and added new ones with a 2 in the name, mostly because go doesn't support polymorphic function signatures.

The other small change I made was adding the ability to recognize the 2009 spec OAEP decryption that my current shibboleth feeds out.  in the long run it might be better to allow users to specify allowed algorithms, if they wish.
