### PR TITLE
fix: [Issue 582] Log successful and unsuccessful sign in attempts 

### DIFF
--- a/samlidp/session.go
+++ b/samlidp/session.go
@@ -38,11 +38,13 @@ func (s *Server) GetSession(w http.ResponseWriter, r *http.Request, req *saml.Id
 	if r.Method == "POST" && r.PostForm.Get("user") != "" {
 		user := User{}
 		if err := s.Store.Get(fmt.Sprintf("/users/%s", r.PostForm.Get("user")), &user); err != nil {
+			s.logger.Printf("ERROR: User '%s' doesn't exists", r.PostForm.Get("user"))
 			s.sendLoginForm(w, r, req, "Invalid username or password")
 			return nil
 		}
 
 		if err := bcrypt.CompareHashAndPassword(user.HashedPassword, []byte(r.PostForm.Get("password"))); err != nil {
+			s.logger.Printf("ERROR: Invalid password for user '%s'", r.PostForm.Get("user"))
 			s.sendLoginForm(w, r, req, "Invalid username or password")
 			return nil
 		}
@@ -75,6 +77,8 @@ func (s *Server) GetSession(w http.ResponseWriter, r *http.Request, req *saml.Id
 			Secure:   r.URL.Scheme == "https",
 			Path:     "/",
 		})
+
+		s.logger.Printf("User '%s' authenticated successfully", r.PostForm.Get("user"))
 		return session
 	}
 

--- a/samlidp/session_test.go
+++ b/samlidp/session_test.go
@@ -63,4 +63,27 @@ func TestSessionsCrud(t *testing.T) {
 	assert.Check(t, is.Equal("{\"sessions\":[]}\n",
 		w.Body.String()))
 
+	// user doesn't exists case
+	w = httptest.NewRecorder()
+	r, _ = http.NewRequest("POST", "https://idp.example.com/login",
+		strings.NewReader("user=unknown&password=dummypassword"))
+	r.Header.Set("Content-type", "application/x-www-form-urlencoded")
+	test.Server.ServeHTTP(w, r)
+	assert.Check(t, is.Equal(http.StatusOK, w.Code))
+	assert.Check(t, is.Equal("text/html; charset=utf-8",
+		w.Header().Get("Content-type")))
+	assert.Check(t, is.Equal(`<html><p>Invalid username or password</p><form method="post" action="https://idp.example.com/sso"><input type="text" name="user" placeholder="user" value="" /><input type="password" name="password" placeholder="password" value="" /><input type="hidden" name="SAMLRequest" value="" /><input type="hidden" name="RelayState" value="" /><input type="submit" value="Log In" /></form></html>`,
+		w.Body.String()))
+
+	// invalid username/password exists case
+	w = httptest.NewRecorder()
+	r, _ = http.NewRequest("POST", "https://idp.example.com/login",
+		strings.NewReader("user=alice&password=dummypassword"))
+	r.Header.Set("Content-type", "application/x-www-form-urlencoded")
+	test.Server.ServeHTTP(w, r)
+	assert.Check(t, is.Equal(http.StatusOK, w.Code))
+	assert.Check(t, is.Equal("text/html; charset=utf-8",
+		w.Header().Get("Content-type")))
+	assert.Check(t, is.Equal(`<html><p>Invalid username or password</p><form method="post" action="https://idp.example.com/sso"><input type="text" name="user" placeholder="user" value="" /><input type="password" name="password" placeholder="password" value="" /><input type="hidden" name="SAMLRequest" value="" /><input type="hidden" name="RelayState" value="" /><input type="submit" value="Log In" /></form></html>`,
+		w.Body.String()))
 }


### PR DESCRIPTION
- Added Info and Error logs upon successful and unsuccessful sign-in attempts
- These logs may help for debugging/auditing/security reviews.
- Sample logs as following:

```
Running tool: /usr/local/go/bin/go test -timeout 30s -run ^TestSessionsCrud$ github.com/crewjam/saml/samlidp
=== RUN   TestSessionsCrud

2025/02/27 19:48:23 User 'alice' authenticated successfully
2025/02/27 19:48:23 ERROR: User 'unknown' doesn't exists
2025/02/27 19:48:23 ERROR: Invalid password for user 'alice'
--- PASS: TestSessionsCrud (0.22s)
PASS
ok      github.com/crewjam/saml/samlidp 0.475s
```