### PR TITLE
Fixes lint issues for a green build

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,8 +10,11 @@ jobs:
   golangci:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
-          version: v1.54.2
+          go-version: stable
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v7
+        with:
+          version: v2.0

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -53,9 +53,7 @@ linters:
       - path: (.+)\.go$
         text: G104 # 'Errors unhandled. (gosec)
     paths:
-      - third_party$
-      - builtin$
-      - examples$
+      - example/.*\.go$
 formatters:
   enable:
     - gofmt

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,72 +1,72 @@
-# Configuration file for golangci-lint
-#
-# https://github.com/golangci/golangci-lint
-#
-# fighting with false positives?
-# https://github.com/golangci/golangci-lint#nolint
-
+version: "2"
 linters:
   enable:
-    - bodyclose # checks whether HTTP response body is closed successfully [fast: false, auto-fix: false]
-    - errcheck # Inspects source code for security problems [fast: true, auto-fix: false]
-    - gocritic # The most opinionated Go source code linter [fast: true, auto-fix: false]
-    - gocyclo # Computes and checks the cyclomatic complexity of functions [fast: true, auto-fix: false]
-    - gofmt # Gofmt checks whether code was gofmt-ed. By default this tool runs with -s option to check for code simplification [fast: true, auto-fix: true]
-    - goimports # Goimports does everything that gofmt does. Additionally it checks unused imports [fast: true, auto-fix: true]
-    - gosec # Errcheck is a program for checking for unchecked errors in go programs. These unchecked errors can be critical bugs in some cases [fast: true, auto-fix: false]
-    - gosimple # Linter for Go source code that specializes in simplifying a code [fast: false, auto-fix: false]
-    - govet # Vet examines Go source code and reports suspicious constructs, such as Printf calls whose arguments do not align with the format string [fast: false, auto-fix: false]
-    - ineffassign # Detects when assignments to existing variables are not used [fast: true, auto-fix: false]
-    - misspell # Finds commonly misspelled English words in comments [fast: true, auto-fix: true]
-    - nakedret # Finds naked returns in functions greater than a specified function length [fast: true, auto-fix: false]
-    - prealloc # Finds slice declarations that could potentially be preallocated [fast: true, auto-fix: false]
-    - revive # Golint differs from gofmt. Gofmt reformats Go source code, whereas golint prints out style mistakes [fast: true, auto-fix: false]
-    - staticcheck # Staticcheck is a go vet on steroids, applying a ton of static analysis checks [fast: false, auto-fix: false]
-    - stylecheck # Stylecheck is a replacement for golint [fast: false, auto-fix: false]
-    - typecheck # Like the front-end of a Go compiler, parses and type-checks Go code [fast: true, auto-fix: false]
-    - unconvert # Remove unnecessary type conversions [fast: true, auto-fix: false]
-    - unparam # Reports unused function parameters [fast: false, auto-fix: false]
-    - unused # Checks Go code for unused constants, variables, functions and types [fast: false, auto-fix: false]
-
+    - bodyclose
+    - gocritic
+    - gocyclo
+    - gosec
+    - misspell
+    - nakedret
+    - prealloc
+    - revive
+    - staticcheck
+    - unconvert
+    - unparam
   disable:
     # TODO(ross): fix errors reported by these checkers and enable them
-    - dupl # Tool for code clone detection [fast: true, auto-fix: false]
-    - gochecknoglobals # Checks that no globals are present in Go code [fast: true, auto-fix: false]
-    - gochecknoinits # Checks that no init functions are present in Go code [fast: true, auto-fix: false]
-    - goconst # Finds repeated strings that could be replaced by a constant [fast: true, auto-fix: false]
-    - lll # Reports long lines [fast: true, auto-fix: false]
-    - depguard # Go linter that checks if package imports are in a list of acceptable packages [fast: true, auto-fix: false]
-linters-settings:
-  goimports:
-    local-prefixes: github.com/crewjam/saml
-  govet:
-    disable:
-      - shadow
-    enable:
-      - asmdecl
-      - assign
-      - atomic
-      - bools
-      - buildtag
-      - cgocall
-      - composites
-      - copylocks
-      - errorsas
-      - httpresponse
-      - loopclosure
-      - lostcancel
-      - nilfunc
-      - printf
-      - shift
-      - stdmethods
-      - structtag
-      - tests
-      - unmarshal
-      - unreachable
-      - unsafeptr
-      - unusedresult
-issues:
-  exclude-use-default: false
-  exclude:
-    - G104 # 'Errors unhandled. (gosec)
-
+    - depguard
+    - dupl
+    - gochecknoglobals
+    - gochecknoinits
+    - goconst
+    - lll
+  settings:
+    govet:
+      enable:
+        - asmdecl
+        - assign
+        - atomic
+        - bools
+        - buildtag
+        - cgocall
+        - composites
+        - copylocks
+        - errorsas
+        - httpresponse
+        - loopclosure
+        - lostcancel
+        - nilfunc
+        - printf
+        - shift
+        - stdmethods
+        - structtag
+        - tests
+        - unmarshal
+        - unreachable
+        - unsafeptr
+        - unusedresult
+      disable:
+        - shadow
+  exclusions:
+    generated: lax
+    rules:
+      - path: (.+)\.go$
+        text: G104 # 'Errors unhandled. (gosec)
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  settings:
+    goimports:
+      local-prefixes:
+        - github.com/crewjam/saml
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/identity_provider.go
+++ b/identity_provider.go
@@ -175,7 +175,7 @@ func (idp *IdentityProvider) Metadata() *EntityDescriptor {
 	}
 
 	if idp.LogoutURL.String() != "" {
-		ed.IDPSSODescriptors[0].SSODescriptor.SingleLogoutServices = []Endpoint{
+		ed.IDPSSODescriptors[0].SingleLogoutServices = []Endpoint{
 			{
 				Binding:  HTTPRedirectBinding,
 				Location: idp.LogoutURL.String(),

--- a/identity_provider_test.go
+++ b/identity_provider_test.go
@@ -242,8 +242,9 @@ func TestIDPCanHandleRequestWithNewSession(t *testing.T) {
 	test := NewIdentityProviderTest(t, applyKey)
 	test.IDP.SessionProvider = &mockSessionProvider{
 		GetSessionFunc: func(w http.ResponseWriter, r *http.Request, req *IdpAuthnRequest) *Session {
-			fmt.Fprintf(w, "RelayState: %s\nSAMLRequest: %s",
+			_, err := fmt.Fprintf(w, "RelayState: %s\nSAMLRequest: %s",
 				req.RelayState, req.RequestBuffer)
+			assert.NilError(t, err)
 			return nil
 		},
 	}
@@ -799,7 +800,8 @@ func TestIDPIDPInitiatedNewSession(t *testing.T) {
 	test := NewIdentityProviderTest(t, applyKey)
 	test.IDP.SessionProvider = &mockSessionProvider{
 		GetSessionFunc: func(w http.ResponseWriter, r *http.Request, req *IdpAuthnRequest) *Session {
-			fmt.Fprintf(w, "RelayState: %s", req.RelayState)
+			_, err := fmt.Fprintf(w, "RelayState: %s", req.RelayState)
+			assert.NilError(t, err)
 			return nil
 		},
 	}
@@ -1068,8 +1070,9 @@ func TestIDPRejectDecompressionBomb(t *testing.T) {
 	test := NewIdentityProviderTest(t)
 	test.IDP.SessionProvider = &mockSessionProvider{
 		GetSessionFunc: func(w http.ResponseWriter, r *http.Request, req *IdpAuthnRequest) *Session {
-			fmt.Fprintf(w, "RelayState: %s\nSAMLRequest: %s",
+			_, err := fmt.Fprintf(w, "RelayState: %s\nSAMLRequest: %s",
 				req.RelayState, req.RequestBuffer)
+			assert.NilError(t, err)
 			return nil
 		},
 	}

--- a/identity_provider_test.go
+++ b/identity_provider_test.go
@@ -126,7 +126,7 @@ func NewIdentityProviderTest(t *testing.T, opts ...idpTestOpts) *IdentityProvide
 		MetadataURL: mustParseURL("https://idp.example.com/saml/metadata"),
 		SSOURL:      mustParseURL("https://idp.example.com/saml/sso"),
 		ServiceProviderProvider: &mockServiceProviderProvider{
-			GetServiceProviderFunc: func(r *http.Request, serviceProviderID string) (*EntityDescriptor, error) {
+			GetServiceProviderFunc: func(_ *http.Request, serviceProviderID string) (*EntityDescriptor, error) {
 				if serviceProviderID == test.SP.MetadataURL.String() {
 					return test.SP.Metadata(), nil
 				}
@@ -134,7 +134,7 @@ func NewIdentityProviderTest(t *testing.T, opts ...idpTestOpts) *IdentityProvide
 			},
 		},
 		SessionProvider: &mockSessionProvider{
-			GetSessionFunc: func(w http.ResponseWriter, r *http.Request, req *IdpAuthnRequest) *Session {
+			GetSessionFunc: func(_ http.ResponseWriter, _ *http.Request, _ *IdpAuthnRequest) *Session {
 				return nil
 			},
 		},
@@ -241,7 +241,7 @@ func TestIDPHTTPCanHandleMetadataRequest(t *testing.T) {
 func TestIDPCanHandleRequestWithNewSession(t *testing.T) {
 	test := NewIdentityProviderTest(t, applyKey)
 	test.IDP.SessionProvider = &mockSessionProvider{
-		GetSessionFunc: func(w http.ResponseWriter, r *http.Request, req *IdpAuthnRequest) *Session {
+		GetSessionFunc: func(w http.ResponseWriter, _ *http.Request, req *IdpAuthnRequest) *Session {
 			_, err := fmt.Fprintf(w, "RelayState: %s\nSAMLRequest: %s",
 				req.RelayState, req.RequestBuffer)
 			assert.NilError(t, err)
@@ -268,7 +268,7 @@ func TestIDPCanHandleRequestWithNewSession(t *testing.T) {
 func TestIDPCanHandleRequestWithExistingSession(t *testing.T) {
 	test := NewIdentityProviderTest(t, applyKey)
 	test.IDP.SessionProvider = &mockSessionProvider{
-		GetSessionFunc: func(w http.ResponseWriter, r *http.Request, req *IdpAuthnRequest) *Session {
+		GetSessionFunc: func(_ http.ResponseWriter, _ *http.Request, _ *IdpAuthnRequest) *Session {
 			return &Session{
 				ID:       "f00df00df00d",
 				UserName: "alice",
@@ -293,7 +293,7 @@ func TestIDPCanHandleRequestWithExistingSession(t *testing.T) {
 func TestIDPCanHandlePostRequestWithExistingSession(t *testing.T) {
 	test := NewIdentityProviderTest(t, applyKey)
 	test.IDP.SessionProvider = &mockSessionProvider{
-		GetSessionFunc: func(w http.ResponseWriter, r *http.Request, req *IdpAuthnRequest) *Session {
+		GetSessionFunc: func(_ http.ResponseWriter, _ *http.Request, _ *IdpAuthnRequest) *Session {
 			return &Session{
 				ID:       "f00df00df00d",
 				UserName: "alice",
@@ -322,7 +322,7 @@ func TestIDPCanHandlePostRequestWithExistingSession(t *testing.T) {
 func TestIDPRejectsInvalidRequest(t *testing.T) {
 	test := NewIdentityProviderTest(t, applyKey)
 	test.IDP.SessionProvider = &mockSessionProvider{
-		GetSessionFunc: func(w http.ResponseWriter, r *http.Request, req *IdpAuthnRequest) *Session {
+		GetSessionFunc: func(_ http.ResponseWriter, _ *http.Request, _ *IdpAuthnRequest) *Session {
 			panic("not reached")
 		},
 	}
@@ -799,7 +799,7 @@ func TestIDPWriteResponse(t *testing.T) {
 func TestIDPIDPInitiatedNewSession(t *testing.T) {
 	test := NewIdentityProviderTest(t, applyKey)
 	test.IDP.SessionProvider = &mockSessionProvider{
-		GetSessionFunc: func(w http.ResponseWriter, r *http.Request, req *IdpAuthnRequest) *Session {
+		GetSessionFunc: func(w http.ResponseWriter, _ *http.Request, req *IdpAuthnRequest) *Session {
 			_, err := fmt.Fprintf(w, "RelayState: %s", req.RelayState)
 			assert.NilError(t, err)
 			return nil
@@ -816,7 +816,7 @@ func TestIDPIDPInitiatedNewSession(t *testing.T) {
 func TestIDPIDPInitiatedExistingSession(t *testing.T) {
 	test := NewIdentityProviderTest(t, applyKey)
 	test.IDP.SessionProvider = &mockSessionProvider{
-		GetSessionFunc: func(w http.ResponseWriter, r *http.Request, req *IdpAuthnRequest) *Session {
+		GetSessionFunc: func(_ http.ResponseWriter, _ *http.Request, _ *IdpAuthnRequest) *Session {
 			return &Session{
 				ID:       "f00df00df00d",
 				UserName: "alice",
@@ -834,7 +834,7 @@ func TestIDPIDPInitiatedExistingSession(t *testing.T) {
 func TestIDPIDPInitiatedBadServiceProvider(t *testing.T) {
 	test := NewIdentityProviderTest(t, applyKey)
 	test.IDP.SessionProvider = &mockSessionProvider{
-		GetSessionFunc: func(w http.ResponseWriter, r *http.Request, req *IdpAuthnRequest) *Session {
+		GetSessionFunc: func(_ http.ResponseWriter, _ *http.Request, _ *IdpAuthnRequest) *Session {
 			return &Session{
 				ID:       "f00df00df00d",
 				UserName: "alice",
@@ -851,7 +851,7 @@ func TestIDPIDPInitiatedBadServiceProvider(t *testing.T) {
 func TestIDPCanHandleUnencryptedResponse(t *testing.T) {
 	test := NewIdentityProviderTest(t, applyKey)
 	test.IDP.SessionProvider = &mockSessionProvider{
-		GetSessionFunc: func(w http.ResponseWriter, r *http.Request, req *IdpAuthnRequest) *Session {
+		GetSessionFunc: func(_ http.ResponseWriter, _ *http.Request, _ *IdpAuthnRequest) *Session {
 			return &Session{ID: "f00df00df00d", UserName: "alice"}
 		},
 	}
@@ -862,7 +862,7 @@ func TestIDPCanHandleUnencryptedResponse(t *testing.T) {
 		&metadata)
 	assert.Check(t, err)
 	test.IDP.ServiceProviderProvider = &mockServiceProviderProvider{
-		GetServiceProviderFunc: func(r *http.Request, serviceProviderID string) (*EntityDescriptor, error) {
+		GetServiceProviderFunc: func(_ *http.Request, serviceProviderID string) (*EntityDescriptor, error) {
 			if serviceProviderID == "https://gitlab.example.com/users/saml/metadata" {
 				return &metadata, nil
 			}
@@ -1029,7 +1029,7 @@ func TestIDPRequestedAttributes(t *testing.T) {
 func TestIDPNoDestination(t *testing.T) {
 	test := NewIdentityProviderTest(t, applyKey)
 	test.IDP.SessionProvider = &mockSessionProvider{
-		GetSessionFunc: func(w http.ResponseWriter, r *http.Request, req *IdpAuthnRequest) *Session {
+		GetSessionFunc: func(_ http.ResponseWriter, _ *http.Request, _ *IdpAuthnRequest) *Session {
 			return &Session{ID: "f00df00df00d", UserName: "alice"}
 		},
 	}
@@ -1038,7 +1038,7 @@ func TestIDPNoDestination(t *testing.T) {
 	err := xml.Unmarshal(golden.Get(t, "TestIDPNoDestination_idp_metadata.xml"), &metadata)
 	assert.Check(t, err)
 	test.IDP.ServiceProviderProvider = &mockServiceProviderProvider{
-		GetServiceProviderFunc: func(r *http.Request, serviceProviderID string) (*EntityDescriptor, error) {
+		GetServiceProviderFunc: func(_ *http.Request, serviceProviderID string) (*EntityDescriptor, error) {
 			if serviceProviderID == "https://gitlab.example.com/users/saml/metadata" {
 				return &metadata, nil
 			}
@@ -1069,7 +1069,7 @@ func TestIDPNoDestination(t *testing.T) {
 func TestIDPRejectDecompressionBomb(t *testing.T) {
 	test := NewIdentityProviderTest(t)
 	test.IDP.SessionProvider = &mockSessionProvider{
-		GetSessionFunc: func(w http.ResponseWriter, r *http.Request, req *IdpAuthnRequest) *Session {
+		GetSessionFunc: func(w http.ResponseWriter, _ *http.Request, req *IdpAuthnRequest) *Session {
 			_, err := fmt.Fprintf(w, "RelayState: %s\nSAMLRequest: %s",
 				req.RelayState, req.RequestBuffer)
 			assert.NilError(t, err)

--- a/samlidp/user.go
+++ b/samlidp/user.go
@@ -85,10 +85,10 @@ func (s *Server) HandlePutUser(c web.C, w http.ResponseWriter, r *http.Request) 
 	} else {
 		existingUser := User{}
 		err := s.Store.Get(fmt.Sprintf("/users/%s", c.URLParams["id"]), &existingUser)
-		switch {
-		case err == nil:
+		switch err {
+		case nil:
 			user.HashedPassword = existingUser.HashedPassword
-		case err == ErrNotFound:
+		case ErrNotFound:
 			// nop
 		default:
 			s.logger.Printf("ERROR: %s", err)

--- a/samlsp/middleware_test.go
+++ b/samlsp/middleware_test.go
@@ -150,7 +150,7 @@ func TestMiddlewareRequireAccountNoCreds(t *testing.T) {
 	test.Middleware.ServiceProvider.AcsURL.Scheme = "http"
 
 	handler := test.Middleware.RequireAccount(
-		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
 			panic("not reached")
 		}))
 
@@ -174,7 +174,7 @@ func TestMiddlewareRequireAccountNoCredsSecure(t *testing.T) {
 	test := NewMiddlewareTest(t)
 
 	handler := test.Middleware.RequireAccount(
-		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
 			panic("not reached")
 		}))
 
@@ -200,7 +200,7 @@ func TestMiddlewareRequireAccountNoCredsPostBinding(t *testing.T) {
 		test.Middleware.ServiceProvider.GetSSOBindingLocation(saml.HTTPRedirectBinding)))
 
 	handler := test.Middleware.RequireAccount(
-		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
 			panic("not reached")
 		}))
 
@@ -256,7 +256,7 @@ func TestMiddlewareRequireAccountCreds(t *testing.T) {
 func TestMiddlewareRequireAccountBadCreds(t *testing.T) {
 	test := NewMiddlewareTest(t)
 	handler := test.Middleware.RequireAccount(
-		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
 			panic("not reached")
 		}))
 
@@ -287,7 +287,7 @@ func TestMiddlewareRequireAccountExpiredCreds(t *testing.T) {
 	}
 
 	handler := test.Middleware.RequireAccount(
-		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
 			panic("not reached")
 		}))
 
@@ -312,7 +312,7 @@ func TestMiddlewareRequireAccountExpiredCreds(t *testing.T) {
 func TestMiddlewareRequireAccountPanicOnRequestToACS(t *testing.T) {
 	test := NewMiddlewareTest(t)
 	handler := test.Middleware.RequireAccount(
-		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
 			panic("not reached")
 		}))
 
@@ -326,7 +326,7 @@ func TestMiddlewareRequireAttribute(t *testing.T) {
 	test := NewMiddlewareTest(t)
 	handler := test.Middleware.RequireAccount(
 		RequireAttribute("eduPersonAffiliation", "Staff")(
-			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusTeapot)
 			})))
 
@@ -344,7 +344,7 @@ func TestMiddlewareRequireAttributeWrongValue(t *testing.T) {
 	test := NewMiddlewareTest(t)
 	handler := test.Middleware.RequireAccount(
 		RequireAttribute("eduPersonAffiliation", "DomainAdmins")(
-			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
 				panic("not reached")
 			})))
 
@@ -362,7 +362,7 @@ func TestMiddlewareRequireAttributeNotPresent(t *testing.T) {
 	test := NewMiddlewareTest(t)
 	handler := test.Middleware.RequireAccount(
 		RequireAttribute("valueThatDoesntExist", "doesntMatter")(
-			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
 				panic("not reached")
 			})))
 
@@ -379,7 +379,7 @@ func TestMiddlewareRequireAttributeNotPresent(t *testing.T) {
 func TestMiddlewareRequireAttributeMissingAccount(t *testing.T) {
 	test := NewMiddlewareTest(t)
 	handler := RequireAttribute("eduPersonAffiliation", "DomainAdmins")(
-		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
 			panic("not reached")
 		}))
 
@@ -455,7 +455,7 @@ func TestMiddlewareDefaultCookieDomainIPv6(t *testing.T) {
 func TestMiddlewareRejectsInvalidRelayState(t *testing.T) {
 	test := NewMiddlewareTest(t)
 
-	test.Middleware.OnError = func(w http.ResponseWriter, r *http.Request, err error) {
+	test.Middleware.OnError = func(w http.ResponseWriter, _ *http.Request, err error) {
 		assert.Check(t, is.Error(err, http.ErrNoCookie.Error()))
 		http.Error(w, "forbidden", http.StatusTeapot)
 	}
@@ -478,7 +478,7 @@ func TestMiddlewareRejectsInvalidRelayState(t *testing.T) {
 func TestMiddlewareRejectsInvalidCookie(t *testing.T) {
 	test := NewMiddlewareTest(t)
 
-	test.Middleware.OnError = func(w http.ResponseWriter, r *http.Request, err error) {
+	test.Middleware.OnError = func(w http.ResponseWriter, _ *http.Request, err error) {
 		assert.Check(t, is.Error(err, "Authentication failed"))
 		http.Error(w, "forbidden", http.StatusTeapot)
 	}

--- a/samlsp/request_tracker_jwt.go
+++ b/samlsp/request_tracker_jwt.go
@@ -70,6 +70,6 @@ func (s JWTTrackedRequestCodec) Decode(signed string) (*TrackedRequest, error) {
 	if !claims.SAMLAuthnRequest {
 		return nil, fmt.Errorf("expected saml-authn-request")
 	}
-	claims.TrackedRequest.Index = claims.Subject
+	claims.Index = claims.Subject
 	return &claims.TrackedRequest, nil
 }

--- a/xmlenc/cbc.go
+++ b/xmlenc/cbc.go
@@ -3,7 +3,7 @@ package xmlenc
 import (
 	"crypto/aes"
 	"crypto/cipher"
-	"crypto/des" // nolint: gas
+	"crypto/des" // nolint: gosec
 	"encoding/base64"
 	"errors"
 	"fmt"

--- a/xmlenc/decrypt.go
+++ b/xmlenc/decrypt.go
@@ -1,8 +1,6 @@
 package xmlenc
 
 import (
-
-	// nolint: gas
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/base64"

--- a/xmlenc/decrypt_test.go
+++ b/xmlenc/decrypt_test.go
@@ -18,6 +18,7 @@ func TestCanDecrypt(t *testing.T) {
 		err := doc.ReadFromBytes(golden.Get(t, "input.xml"))
 		assert.Check(t, err)
 
+		//nolint:gosec
 		keyPEM := "-----BEGIN RSA PRIVATE KEY-----\nMIICXgIBAAKBgQDU8wdiaFmPfTyRYuFlVPi866WrH/2JubkHzp89bBQopDaLXYxi\n3PTu3O6Q/KaKxMOFBqrInwqpv/omOGZ4ycQ51O9I+Yc7ybVlW94lTo2gpGf+Y/8E\nPsVbnZaFutRctJ4dVIp9aQ2TpLiGT0xX1OzBO/JEgq9GzDRf+B+eqSuglwIDAQAB\nAoGBAMuy1eN6cgFiCOgBsB3gVDdTKpww87Qk5ivjqEt28SmXO13A1KNVPS6oQ8SJ\nCT5Azc6X/BIAoJCURVL+LHdqebogKljhH/3yIel1kH19vr4E2kTM/tYH+qj8afUS\nJEmArUzsmmK8ccuNqBcllqdwCZjxL4CHDUmyRudFcHVX9oyhAkEA/OV1OkjM3CLU\nN3sqELdMmHq5QZCUihBmk3/N5OvGdqAFGBlEeewlepEVxkh7JnaNXAXrKHRVu/f/\nfbCQxH+qrwJBANeQERF97b9Sibp9xgolb749UWNlAdqmEpmlvmS202TdcaaT1msU\n4rRLiQN3X9O9mq4LZMSVethrQAdX1whawpkCQQDk1yGf7xZpMJ8F4U5sN+F4rLyM\nRq8Sy8p2OBTwzCUXXK+fYeXjybsUUMr6VMYTRP2fQr/LKJIX+E5ZxvcIyFmDAkEA\nyfjNVUNVaIbQTzEbRlRvT6MqR+PTCefC072NF9aJWR93JimspGZMR7viY6IM4lrr\nvBkm0F5yXKaYtoiiDMzlOQJADqmEwXl0D72ZG/2KDg8b4QZEmC9i5gidpQwJXUc6\nhU+IVQoLxRq0fBib/36K9tcrrO5Ba4iEvDcNY+D8yGbUtA==\n-----END RSA PRIVATE KEY-----\n"
 		b, _ := pem.Decode([]byte(keyPEM))
 		key, err := x509.ParsePKCS1PrivateKey(b.Bytes)

--- a/xmlenc/digest.go
+++ b/xmlenc/digest.go
@@ -6,7 +6,7 @@ import (
 	"crypto/sha512"
 	"hash"
 
-	//nolint:staticcheck // We should support this for legacy reasons.
+	//nolint:staticcheck,gosec // We should support this for legacy reasons.
 	"golang.org/x/crypto/ripemd160"
 )
 

--- a/xmlenc/fuzz.go
+++ b/xmlenc/fuzz.go
@@ -9,6 +9,7 @@ import (
 )
 
 var testKey = func() *rsa.PrivateKey {
+	//nolint:gosec
 	const keyStr = `-----BEGIN RSA PRIVATE KEY-----
 MIICXQIBAAKBgQDkXTUsWzRVpUHjbDpWCfYDfXmQ/q4LkaioZoTpu4ut1Q3eQC5t
 gD14agJhgT8yzeY5S/YNlwCyuVkjuFyoyTHFX2IOPpz7jnh4KnQ+B1IH9fY/+kmk

--- a/xmlenc/pubkey.go
+++ b/xmlenc/pubkey.go
@@ -147,10 +147,10 @@ func PKCS1v15() RSA {
 		BlockCipher:  AES256CBC,
 		DigestMethod: nil,
 		algorithm:    "http://www.w3.org/2001/04/xmlenc#rsa-1_5",
-		keyEncrypter: func(e RSA, pubKey *rsa.PublicKey, plaintext []byte) ([]byte, error) {
+		keyEncrypter: func(_ RSA, pubKey *rsa.PublicKey, plaintext []byte) ([]byte, error) {
 			return rsa.EncryptPKCS1v15(RandReader, pubKey, plaintext)
 		},
-		keyDecrypter: func(e RSA, privKey *rsa.PrivateKey, ciphertext []byte) ([]byte, error) {
+		keyDecrypter: func(_ RSA, privKey *rsa.PrivateKey, ciphertext []byte) ([]byte, error) {
 			return rsa.DecryptPKCS1v15(RandReader, privKey, ciphertext)
 		},
 	}


### PR DESCRIPTION
Upgrades golangci-lint to v2 and migrates the configuration in .golangci.yml to newer format.

The migration itself was done with `golangci-lint migrate` which hopefully preserves as much functionality as possible. I've modified the configuration file to exclude the files under example/

The rest of the changes are addressing issues found by the linters after the migration.

I've kept the commits separate in the pull request to make it easier to review, or to reject individual lint fixes. Let me know if you want me to squash to one commit.