### PR TITLE
Add an AssertionHandler to the middleware

### DIFF
--- a/samlsp/basic_assertion_handler.go
+++ b/samlsp/basic_assertion_handler.go
@@ -1,0 +1,15 @@
+package samlsp
+
+import (
+	"github.com/crewjam/saml"
+)
+
+var _ AssertionHandler = NopAssertionHandler{}
+
+// NopAssertionHandler is an implementation of AssertionHandler that does nothing.
+type NopAssertionHandler struct{}
+
+// HandleAssertion is called and passed a SAML assertion. This implementation does nothing.
+func (as NopAssertionHandler) HandleAssertion(_ *saml.Assertion) error {
+	return nil
+}

--- a/samlsp/new.go
+++ b/samlsp/new.go
@@ -131,6 +131,12 @@ func DefaultServiceProvider(opts Options) saml.ServiceProvider {
 	}
 }
 
+// DefaultAssertionHandler returns the default AssertionHandler for the provided options,
+// a NopAssertionHandler configured to do nothing.
+func DefaultAssertionHandler(_ Options) NopAssertionHandler {
+	return NopAssertionHandler{}
+}
+
 // New creates a new Middleware with the default providers for the
 // given options.
 //
@@ -139,11 +145,12 @@ func DefaultServiceProvider(opts Options) saml.ServiceProvider {
 // in the returned Middleware.
 func New(opts Options) (*Middleware, error) {
 	m := &Middleware{
-		ServiceProvider: DefaultServiceProvider(opts),
-		Binding:         "",
-		ResponseBinding: saml.HTTPPostBinding,
-		OnError:         DefaultOnError,
-		Session:         DefaultSessionProvider(opts),
+		ServiceProvider:  DefaultServiceProvider(opts),
+		Binding:          "",
+		ResponseBinding:  saml.HTTPPostBinding,
+		OnError:          DefaultOnError,
+		Session:          DefaultSessionProvider(opts),
+		AssertionHandler: DefaultAssertionHandler(opts),
 	}
 	m.RequestTracker = DefaultRequestTracker(opts, &m.ServiceProvider)
 	if opts.UseArtifactResponse {

--- a/samlsp/saml_assertion_handler.go
+++ b/samlsp/saml_assertion_handler.go
@@ -1,0 +1,9 @@
+package samlsp
+
+import "github.com/crewjam/saml"
+
+// AssertionHandler is an interface implemented by types that can handle
+// assertions and add extra functionality
+type AssertionHandler interface {
+	HandleAssertion(assertion *saml.Assertion) error
+}


### PR DESCRIPTION
> **Note**: This is a rebase of [kevcoxe](https://github.com/kevcoxe) 's PR #509 with conflicts fixed. 
> I've renamed some things, but otherwise it is as submitted. 

I have been using this repo in addition to [itzg/saml-auth-proxy](https://github.com/itzg/saml-auth-proxy) but I wanted to add some extra functionality where on login take the assertion from the SAML provider and add RBAC to Grafana.

To do this I added a `AssertionHandler` to samlsp middleware. Inside of the `ServeACS` function before creating the session I call the `AssertionHandler.HandleAssertion` function and give it the assertion.

This way you can create your own AssertionHandler and have it do whatever you want, in my case add RBAC to opensource Grafana.

Let me know if there is something I should change. I am currently using a fork for my purpose but would love to see this added upstream.