### PR TITLE
Extract `NameID` with full text (including comments)

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -821,7 +821,7 @@ type NameID struct {
 	SPNameQualifier string `xml:",attr"`
 	Format          string `xml:",attr"`
 	SPProvidedID    string `xml:",attr"`
-	Value           string `xml:",chardata"`
+	Value           string `xml:",innerxml"`
 }
 
 // Element returns an etree.Element representing the object in XML form.


### PR DESCRIPTION
Hi folks!

At [Fleet](https://github.com/fleetdm/fleet) we are attempting to replace our own SAML implementation with crewjam/saml.
One of our internal tests failed because of `NameID` extraction (crewjam/saml will remove any comments from the `NameID` field). 

This PR fixes the issue using the approach [Duo recommended for remediation](https://duo.com/blog/duo-finds-saml-vulnerabilities-affecting-multiple-implementations):
> If You Maintain a SAML Processing Library
>> The most obvious remediation here is ensuring your SAML library is extracting the full text of a given XML element when comments are present.