### PR TITLE
SAML post to correct URL and make example run locally

### DIFF
--- a/example/service.go
+++ b/example/service.go
@@ -121,8 +121,8 @@ OwJlNCASPZRH/JmF8tX0hoHuAQ==
 )
 
 func main() {
-	rootURLstr := flag.String("url", "https://962766ce.ngrok.io", "The base URL of this service")
-	idpMetadataURLstr := flag.String("idp", "https://516becc2.ngrok.io/metadata", "The metadata URL for the IDP")
+	rootURLstr := flag.String("url", "http://localhost:8090", "The base URL of this service")
+	idpMetadataURLstr := flag.String("idp", "http://localhost:8080/metadata", "The metadata URL for the IDP")
 	flag.Parse()
 
 	keyPair, err := tls.X509KeyPair(cert, key)
@@ -175,11 +175,11 @@ func main() {
 	}
 
 	mux := http.NewServeMux()
-	mux.Handle("GET /saml/", samlSP)
-	mux.HandleFunc("GET /{link}", ServeLink)
+	mux.Handle("/saml/", samlSP)
+	mux.HandleFunc("GET /links/{link}", ServeLink)
 	mux.Handle("GET /whoami", samlSP.RequireAccount(http.HandlerFunc(ServeWhoami)))
-	mux.Handle("POST /", samlSP.RequireAccount(http.HandlerFunc(CreateLink)))
-	mux.Handle("GET /", samlSP.RequireAccount(http.HandlerFunc(ListLinks)))
+	mux.Handle("POST /links", samlSP.RequireAccount(http.HandlerFunc(CreateLink)))
+	mux.Handle("GET /links", samlSP.RequireAccount(http.HandlerFunc(ListLinks)))
 
-	http.ListenAndServe(":8080", mux)
+	http.ListenAndServe(":8090", mux)
 }

--- a/samlidp/session.go
+++ b/samlidp/session.go
@@ -129,7 +129,7 @@ func (s *Server) sendLoginForm(w http.ResponseWriter, req *saml.IdpAuthnRequest,
 		RelayState  string
 	}{
 		Toast:       toast,
-		URL:         req.IDP.LoginURL.String(),
+		URL:         req.IDP.SSOURL.String(),
 		SAMLRequest: base64.StdEncoding.EncodeToString(req.RequestBuffer),
 		RelayState:  req.RelayState,
 	}


### PR DESCRIPTION
Hi Ross, very useful project, I made three changes to make the example work:
- The IdP should post the authentication form to URLSSO, not URLLogin, otherwise the flow stops there
- I fixed the URLs for the example service so it runs in `localhost` to start with and without conflicting ports for SP and IdP
- The ServeMux in Go 1.24+ can't identify correct routes and we also need to be able to POST to `/saml`