### PR TITLE
Update schema for AuthenticatingAuthority and add tests

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -1155,10 +1155,10 @@ func (a *SubjectLocality) Element() *etree.Element {
 //
 // See http://docs.oasis-open.org/security/saml/v2.0/saml-core-2.0-os.pdf §2.7.2.2
 type AuthnContext struct {
-	AuthnContextClassRef *AuthnContextClassRef
+	AuthnContextClassRef      *AuthnContextClassRef
+	AuthenticatingAuthorities []AuthenticatingAuthority `xml:"AuthenticatingAuthority"`
 	// AuthnContextDecl          *AuthnContextDecl        ... TODO
 	// AuthnContextDeclRef       *AuthnContextDeclRef     ... TODO
-	// AuthenticatingAuthorities []AuthenticatingAuthority... TODO
 }
 
 // Element returns an etree.Element representing the object in XML form.
@@ -1166,6 +1166,10 @@ func (a *AuthnContext) Element() *etree.Element {
 	el := etree.NewElement("saml:AuthnContext")
 	if a.AuthnContextClassRef != nil {
 		el.AddChild(a.AuthnContextClassRef.Element())
+	}
+
+	for _, v := range a.AuthenticatingAuthorities {
+		el.AddChild(v.Element())
 	}
 	return el
 }
@@ -1180,6 +1184,20 @@ type AuthnContextClassRef struct {
 // Element returns an etree.Element representing the object in XML form.
 func (a *AuthnContextClassRef) Element() *etree.Element {
 	el := etree.NewElement("saml:AuthnContextClassRef")
+	el.SetText(a.Value)
+	return el
+}
+
+// AuthenticatingAuthority represents the SAML element AuthenticatingAuthority.
+//
+// See http://docs.oasis-open.org/security/saml/v2.0/saml-core-2.0-os.pdf §2.7.2.2
+type AuthenticatingAuthority struct {
+	Value string `xml:",chardata"`
+}
+
+// Element returns an etree.Element representing the object in XML form.
+func (a *AuthenticatingAuthority) Element() *etree.Element {
+	el := etree.NewElement("saml:AuthenticatingAuthority")
 	el.SetText(a.Value)
 	return el
 }

--- a/schema_test.go
+++ b/schema_test.go
@@ -108,6 +108,54 @@ func TestRequestedAuthnContext(t *testing.T) {
 		string(x)))
 }
 
+func TestAuthenticatingAuthority(t *testing.T) {
+	expected := AuthenticatingAuthority{
+		Value: "value",
+	}
+
+	doc := etree.NewDocument()
+	doc.SetRoot(expected.Element())
+	x, err := doc.WriteToBytes()
+	assert.Check(t, err)
+	assert.Check(t, is.Equal(`<saml:AuthenticatingAuthority>value</saml:AuthenticatingAuthority>`,
+		string(x)))
+}
+
+func TestAuthnContextNoAuthenticatingAuthority(t *testing.T) {
+	expected := AuthnContext{
+		AuthnContextClassRef: &AuthnContextClassRef{
+			Value: "value",
+		},
+		AuthenticatingAuthorities: nil,
+	}
+
+	doc := etree.NewDocument()
+	doc.SetRoot(expected.Element())
+	x, err := doc.WriteToBytes()
+	assert.Check(t, err)
+	assert.Check(t, is.Equal(`<saml:AuthnContext><saml:AuthnContextClassRef>value</saml:AuthnContextClassRef></saml:AuthnContext>`,
+		string(x)))
+}
+
+func TestAuthnContextMultiAuthenticatingAuthority(t *testing.T) {
+	expected := AuthnContext{
+		AuthnContextClassRef: &AuthnContextClassRef{
+			Value: "value",
+		},
+		AuthenticatingAuthorities: []AuthenticatingAuthority{
+			{Value: "value1"},
+			{Value: "value2"},
+		},
+	}
+
+	doc := etree.NewDocument()
+	doc.SetRoot(expected.Element())
+	x, err := doc.WriteToBytes()
+	assert.Check(t, err)
+	assert.Check(t, is.Equal(`<saml:AuthnContext><saml:AuthnContextClassRef>value</saml:AuthnContextClassRef><saml:AuthenticatingAuthority>value1</saml:AuthenticatingAuthority><saml:AuthenticatingAuthority>value2</saml:AuthenticatingAuthority></saml:AuthnContext>`,
+		string(x)))
+}
+
 func TestArtifactResolveElement(t *testing.T) {
 	issueInstant := time.Date(2020, 7, 21, 12, 30, 45, 0, time.UTC)
 	expected := ArtifactResolve{


### PR DESCRIPTION
This adds support for the AuthenticatingAuthority attribute as defined in http://docs.oasis-open.org/security/saml/v2.0/saml-core-2.0-os.pdf §2.7.2.2

Also includes 3 tests to ensure it is working properly. I have already included this in an upstream project and it is working great.

Please let me know if you need me to fix anything.